### PR TITLE
Enable page archival & replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ guide for an introduction to the framework.
 
 Environment variables can be set in development using the [dotenv](https://github.com/bkeepers/dotenv) gem.
 
-Consistent but sensitive credentials should be added to `config/credentials.yml.env` by using `$ rails credentials:edit`
+Consistent but sensitive credentials should be added to `config/credentials.yml.enc` by using `$ rails credentials:edit`
 
-Staging credentials should be added to `config/credentials/staging.yml.env` by using `$ rails credentials:edit --environment staging`
+Staging credentials should be added to `config/credentials/staging.yml.enc` by using `$ rails credentials:edit --environment staging`
 
-Production credentials should be added to `config/credentials/production.yml.env` by using `$ rails credentials:edit --environment production`
+Production credentials should be added to `config/credentials/production.yml.enc` by using `$ rails credentials:edit --environment production`
 
 Any changes to variables in `.env` that should not be checked into git should be set
 in `.env.local`.

--- a/_pages/expiration-testing/index.md
+++ b/_pages/expiration-testing/index.md
@@ -1,0 +1,6 @@
+---
+title: Expiration Testing
+public: true
+expires_at: 2022-03-16T21:30:15.386Z
+---
+This post will expire at 5:30pm on March 16

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,7 +14,7 @@ class PagesController < ApplicationController
   end
 
   def page
-    @page = Page.find_by_path Pathname.new(params[:path])
+    @page = Page.find_by_path params[:path]
     if @page.obsolete?
       redirect_to content_page_path(path: @page.redirect_page)
       return

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,6 +15,10 @@ class PagesController < ApplicationController
 
   def page
     @page = Page.find_by_path Pathname.new(params[:path])
+    if @page.obsolete?
+      redirect_to content_page_path(path: @page.redirect_page)
+      return
+    end
     if @page.public? || user_signed_in?
       render formats: :html
     else

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -28,6 +28,16 @@ class Page
     parsed_file["public"]
   end
 
+  def obsolete?
+    redirect_page.present?
+  end
+
+  def redirect_page
+    if parsed_file["redirect_to"].present?
+      @redirect_page ||= self.class.find_by_path(Pathname.new(parsed_file["redirect_to"]), false).filename
+    end
+  end
+
   def expired?
     expires_at&.past?
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -4,7 +4,8 @@ class Page
     filename = path.basename(".md")
     full_path = Rails.root.join "_pages", dirname, "#{filename}.md"
     if File.exist?(full_path)
-      new dirname, filename, FrontMatterParser::Parser.parse_file(full_path)
+      loader = FrontMatterParser::Loader::Yaml.new(allowlist_classes: [Time])
+      new dirname, filename, FrontMatterParser::Parser.parse_file(full_path, loader: loader)
     elsif try_index
       find_by_path(dirname.join(filename, "index.md"), false)
     else
@@ -25,6 +26,14 @@ class Page
 
   def public?
     parsed_file["public"]
+  end
+
+  def expired?
+    expires_at&.past?
+  end
+
+  def expires_at
+    parsed_file["expires_at"]
   end
 
   def title

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,7 +1,7 @@
 class Page
   def self.find_by_path(path, try_index = true)
-    dirname = path.dirname
-    filename = path.basename(".md")
+    dirname = Pathname(path).dirname
+    filename = Pathname(path).basename(".md")
     full_path = Rails.root.join "_pages", dirname, "#{filename}.md"
     if File.exist?(full_path)
       loader = FrontMatterParser::Loader::Yaml.new(allowlist_classes: [Time])
@@ -34,7 +34,7 @@ class Page
 
   def redirect_page
     if parsed_file["redirect_to"].present?
-      @redirect_page ||= self.class.find_by_path(Pathname.new(parsed_file["redirect_to"]), false).filename
+      @redirect_page ||= self.class.find_by_path(parsed_file["redirect_to"], false).filename
     end
   end
 

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -7,7 +7,7 @@
   <% @pages.each do |p| %>
     <li>
       <% if user_signed_in? || p.public? %>
-        <%= link_to p.title, "/#{p.filename}" %>
+        <%= link_to p.title, content_page_path(path: p.filename) %>
       <% else %>
         <%= p.title %> (Private Access)
       <% end %>

--- a/app/views/pages/netlify_config.yaml.erb
+++ b/app/views/pages/netlify_config.yaml.erb
@@ -16,4 +16,5 @@ collections:
     fields:
       - {label: "Title", name: "title"}
       - {label: "Public", name: "public", widget: "boolean", default: true}
+      - {label: "Expires At", name: "expires_at", widget: "datetime", default: ""}
       - {label: "Body", name: "body", widget: "markdown"}

--- a/app/views/pages/netlify_config.yaml.erb
+++ b/app/views/pages/netlify_config.yaml.erb
@@ -17,4 +17,11 @@ collections:
       - {label: "Title", name: "title"}
       - {label: "Public", name: "public", widget: "boolean", default: true}
       - {label: "Expires At", name: "expires_at", widget: "datetime", default: ""}
+      - label: "Replaced By Page"
+        name: "redirect_to"
+        widget: "relation"
+        collection: "page"
+        search_fields: ["title", "{{slug}}"]
+        value_field: "{{slug}}"
+        display_fields: ["title", "{{slug}}"]
       - {label: "Body", name: "body", widget: "markdown"}

--- a/app/views/pages/page.html.erb
+++ b/app/views/pages/page.html.erb
@@ -1,3 +1,14 @@
 <h1><%= @page.title %></h1>
 
+<% if @page.expired? %>
+  <div class="usa-alert usa-alert--warning">
+    <div class="usa-alert__body">
+      <h4 class="usa-alert__heading">This page has expired</h4>
+      <p class="usa-alert__text">
+        This page expired on <%= @page.expires_at.strftime("%B %d, %Y") %>
+      </p>
+    </div>
+  </div>
+<% end %>
+
 <%= @page.rendered_content %>

--- a/bin/dev
+++ b/bin/dev
@@ -6,4 +6,4 @@ then
   gem install foreman
 fi
 
-foreman start -f Procfile.dev "$@"
+foreman start -f Procfile.dev -e /dev/null "$@"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
 
   root "pages#home"
 
-  get "*path", to: "pages#page"
+  get "*path", to: "pages#page", as: :content_page
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
Pages can be marked with two ways of managing content lifecycle:

* with an expiration date/time that displays a warning banner after expiration
* with a new page URL to redirect users to

Closes out the experiment for https://trello.com/c/P4ScztUm/127-netlify-page-archival-experiment