### PR TITLE
Handle blank strings in place for `expires_at`

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -39,7 +39,7 @@ class Page
   end
 
   def expired?
-    expires_at&.past?
+    expires_at.present? && expires_at.past?
   end
 
   def expires_at


### PR DESCRIPTION
Making `expires_at` optional means that netlify sets the field to an empty string instead of leaving it out of the metadata.