### PR TITLE
Switch out minimist for minimist-lite

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "pa11y-ci": "^3.0.1"
   },
   "resolutions": {
-    "netlify-cms-app/**/trim": "0.0.3"
+    "netlify-cms-app/**/trim": "0.0.3",
+    "minimist": "npm:minimist-lite"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3974,10 +3974,10 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@^1.2.0, minimist@^1.2.5, "minimist@npm:minimist-lite":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/minimist-lite/-/minimist-lite-2.2.0.tgz#43992acac6bb17e78acb6eee784d1da2f7cc3216"
+  integrity sha512-o9M0Iz5ELqCT4NzeaZHBBlV4+ruOGGWV6lVxFoghC6Wvp4W6ECbBBpmDRHdk72O/sMh3QT0c/0XDKhtGlztRZw==
 
 mkdirp-classic@^0.5.2:
   version "0.5.3"


### PR DESCRIPTION
Addresses `yarn audit` failure: https://github.com/advisories/GHSA-xvch-5gv4-984h