### PR TITLE
Build JS in "development" mode locally

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
 web: bin/rails server -p 3000
-js: yarn build --watch
+js: yarn build:dev --watch
 css: yarn build:css --watch

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "build": "webpack --config webpack.config.js",
+    "build:dev": "yarn build --mode=development",
     "build:css": "postcss ./app/assets/stylesheets/application.postcss.css -o ./app/assets/builds/application.css",
     "postinstall": "patch-package"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,6 @@ const path    = require("path")
 const webpack = require("webpack")
 
 module.exports = {
-  mode: "production",
   devtool: "source-map",
   entry: {
     application: "./app/javascript/application.js",


### PR DESCRIPTION
Minification of the Netlify bundle was taking ~40s when running locally. This commit does local builds in [Webpack's development mode](https://webpack.js.org/configuration/mode), which does not minify. (Webpack will build in production by default if `mode` is not specified.)