### PR TITLE
Nav editing

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -5,10 +5,7 @@
     "hideElements": ".usa-nav__primary-item > .usa-accordion__button > span"
   },
   "urls": [
-    {
-      "url": "http://localhost:3000",
-      "screenCapture": "test.png"
-    },
+    "http://localhost:3000",
     "http://localhost:3000/public-page",
     "http://localhost:3000/404"
   ]

--- a/_pages/home/index.md
+++ b/_pages/home/index.md
@@ -1,0 +1,5 @@
+---
+title: Home
+---
+
+This is the home page!

--- a/_pages/home/index.md
+++ b/_pages/home/index.md
@@ -1,5 +1,6 @@
 ---
 title: Home
+public: true
 ---
 
 This is the home page!

--- a/_settings/navigation.yml
+++ b/_settings/navigation.yml
@@ -1,0 +1,5 @@
+items:
+  - page: home/index
+  - page: wellness/index
+    include_children: true
+  - page: contact/index

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,8 @@ module ApplicationHelper
   def footer
     @footer ||= Footer.load
   end
+
+  def menu
+    @menu ||= Menu.load(Rails.root.join("_settings", "navigation.yml"), pages)
+  end
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,0 +1,52 @@
+# A Menu is a view into a hierarchy of pages.
+class Menu
+  class Item
+    def initialize(page, text = nil, include_children = false)
+      @page = page
+      @text = text
+      @include_children = include_children
+    end
+
+    def children
+      @children ||= if @include_children
+        @page.children.map { |child| Menu::Item.new child }
+      else
+        []
+      end
+    end
+
+    def has_children?
+      @include_children && @page.has_children?
+    end
+
+    def path
+      @page.filename
+    end
+
+    def public?
+      @page.public?
+    end
+
+    def text
+      @text || @page.title
+    end
+  end
+
+  def self.load(file, pages)
+    data = YAML.safe_load File.read(file), fallback: {}
+    items = (data["items"] || []).map { |i|
+      page = Page.find_by_slug(i["page"], pages)
+      if page
+        self::Item.new(page, i["text"], i["include_children"])
+      end
+    }
+
+    new items.compact
+  end
+
+  attr_reader :items
+
+  def initialize(items)
+    @items = items
+  end
+end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -36,7 +36,7 @@ class Menu
     items = (data["items"] || []).map { |i|
       page = Page.find_by_slug(i["page"], pages)
       if page
-        self::Item.new(page, i["text"], i["include_children"])
+        Item.new(page, i["text"], i["include_children"])
       end
     }
 

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,34 +1,33 @@
 # A Menu is a view into a hierarchy of pages.
 class Menu
   class Item
+    attr_reader :page, :text
+    delegate :public?, to: :page
+
     def initialize(page, text = nil, include_children = false)
       @page = page
-      @text = text
+      @text = text || page.title
       @include_children = include_children
     end
 
+    def include_children?
+      !!@include_children
+    end
+
     def children
-      @children ||= if @include_children
-        @page.children.map { |child| Menu::Item.new child }
+      @children ||= if include_children?
+        page.children.map { |child| Menu::Item.new child }
       else
         []
       end
     end
 
     def has_children?
-      @include_children && @page.has_children?
+      include_children? && page.has_children?
     end
 
     def path
-      @page.filename
-    end
-
-    def public?
-      @page.public?
-    end
-
-    def text
-      @text || @page.title
+      page.filename
     end
   end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -14,6 +14,24 @@ class Page
     end
   end
 
+  # Recursively searches a page hierarchy for a particular slug.
+  # Netlify slugs don't have leading or trailing '/' characters, and may
+  # end in `/index`.
+  def self.find_by_slug(slug, pages)
+    filename = Pathname(slug.to_s.gsub(/\/index$/, ""))
+
+    pages.each do |p|
+      if p.filename == filename
+        return p
+      else
+        child = find_by_slug slug, p.children
+        return child unless child.nil?
+      end
+    end
+
+    nil
+  end
+
   # constructs a hierarchy of Page objects from the filesystem at <dir>.
   def self.build_hierarchy(dir, parent_path = "")
     dir = Pathname(dir)

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -16,22 +16,22 @@
           <%= image_tag "uswds/dist/img/usa-icons/close.svg", role: "img", alt: t('shared.header.close') %>
         </button>
         <ul class="usa-nav__primary usa-accordion">
-          <% pages.each_with_index do |p, index| %>
-            <% if user_signed_in? || p.public? %>
+          <% menu.items.each_with_index do |item, index| %>
+            <% if user_signed_in? || item.public? %>
               <li class="usa-nav__primary-item">
-                <% if p.has_children? %>
+                <% if item.has_children? %>
                   <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="extended-nav-section-<%= index %>">
-                    <span><%= p.title %></span>
+                    <span><%= item.text %></span>
                   </button>
                   <ul id="extended-nav-section-<%= index %>" class="usa-nav__submenu" hidden="">
-                    <% p.children.each do |child| %>
+                    <% item.children.each do |child| %>
                       <li class="usa-nav__submenu-item">
-                        <%= link_to child.title, content_page_path(child.filename), class: "usa-nav__link" %>
+                        <%= link_to child.text, content_page_path(child.path), class: "usa-nav__link" %>
                       </li>
                     <% end %>
                   </ul>
                 <% else %>
-                  <%= link_to p.title, content_page_path(p.filename), class: "usa-nav__link" %>
+                  <%= link_to item.text, content_page_path(item.path), class: "usa-nav__link" %>
                 <% end %>
               </li>
             <% end %>

--- a/app/views/pages/netlify_config.yaml.erb
+++ b/app/views/pages/netlify_config.yaml.erb
@@ -47,6 +47,31 @@ collections:
       preview: false
 
     files:
+
+      - name: "navigation"
+        label: "Navigation"
+        description: "Configure primary navigation at the top of every page."
+        file: "_settings/navigation.yml"
+        fields:
+          - name: items
+            label: Primary navigation items
+            label_singular: Primary navigation item
+            widget: list
+            summary: "{{fields.page}}"
+            fields: 
+              - name: page
+                widget: relation
+                collection: page
+                value_field: "{{slug}}"
+                display_fields: ["{{title}} ({{slug}})"]
+                search_fields: ["title"]
+              - name: text
+                required: false
+                hint: "Leave blank to use the page title."
+              - name: include_children
+                label: "Include children?"
+                widget: boolean
+                
       - name: footer
         label: "Site footer"
         description: "Configure the footer at the bottom of every page."
@@ -74,3 +99,4 @@ collections:
                 widget: string
               - name: text
                 widget: string
+

--- a/spec/fixtures/files/_settings/navigation.yml
+++ b/spec/fixtures/files/_settings/navigation.yml
@@ -1,0 +1,6 @@
+items:
+  - page: page-one/index
+  - page: page-two/index
+    text: Custom text
+  - page: page-one/child-one/index
+    include_children: true

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -5,8 +5,11 @@ RSpec.describe Menu, type: :model do
     allow(Rails).to receive(:root).and_return(file_fixture("_pages").join("..").cleanpath)
   }
 
+  let(:pages) {
+    Page.build_hierarchy(file_fixture("_pages"))
+  }
+
   subject {
-    pages = Page.build_hierarchy(file_fixture("_pages"))
     described_class.load(
       file_fixture("_settings/navigation.yml").cleanpath,
       pages

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Menu, type: :model do
+  before {
+    allow(Rails).to receive(:root).and_return(file_fixture("_pages").join("..").cleanpath)
+  }
+
+  subject {
+    pages = Page.build_hierarchy(file_fixture("_pages"))
+    described_class.load(
+      file_fixture("_settings/navigation.yml").cleanpath,
+      pages
+    )
+  }
+
+  describe ".items" do
+    it "finds all items" do
+      expect(subject.items).to have_attributes(size: 3)
+    end
+    it "defaults text to page title" do
+      expect(subject.items[0].text).to eql("Page One")
+    end
+    it "allows customizing text" do
+      expect(subject.items[1].text).to eql("Custom text")
+    end
+    it "hides children by default" do
+      expect(subject.items[0].children).to have_attributes(size: 0)
+    end
+    it "shows children if include_children is set" do
+      expect(subject.items[2].children).to have_attributes(size: 1)
+    end
+  end
+end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -20,14 +20,16 @@ RSpec.describe Page, type: :model do
   end
 
   describe ".find_by_slug" do
+    let(:pages) {
+      described_class.build_hierarchy(file_fixture("_pages").cleanpath)
+    }
+
     it "finds a root-level page" do
-      pages = described_class.build_hierarchy(file_fixture("_pages").cleanpath)
       page = described_class.find_by_slug("page-one/index", pages)
       expect(page).not_to be(nil)
       expect(page.filename.to_s).to eq("page-one")
     end
     it "finds a child page" do
-      pages = described_class.build_hierarchy(file_fixture("_pages").cleanpath)
       page = described_class.find_by_slug("page-one/child-one/index", pages)
       expect(page).not_to be(nil)
       expect(page.filename.to_s).to eq("page-one/child-one")

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -19,6 +19,22 @@ RSpec.describe Page, type: :model do
     end
   end
 
+  describe ".find_by_slug" do
+    it "finds a root-level page" do
+      pages = described_class.build_hierarchy(file_fixture("_pages").cleanpath)
+      page = described_class.find_by_slug("page-one/index", pages)
+      expect(page).not_to be(nil)
+      expect(page.filename.to_s).to eq("page-one")
+    end
+    it "finds a child page" do
+      pages = described_class.build_hierarchy(file_fixture("_pages").cleanpath)
+      page = described_class.find_by_slug("page-one/child-one/index", pages)
+      expect(page).not_to be(nil)
+      expect(page.filename.to_s).to eq("page-one/child-one")
+      expect(page.children.length).to eql(1)
+    end
+  end
+
   describe ".build_hierarchy" do
     it "builds a hierarchy" do
       h = described_class.build_hierarchy(file_fixture("_pages").cleanpath)


### PR DESCRIPTION
<img width="873" alt="screenshot of nav editing interface" src="https://user-images.githubusercontent.com/364697/160027746-c9f9bfe8-089b-418e-b40d-cb82687f992e.png">

This PR adds basic editing of the global top navigation using a Netlify `list` widget.  Fun facts:

- Navigation is stored in `_settings/navigation.yml`. 
- There's a companion `Menu` model on the Rails side

Right now everything in a menu needs a corresponding thing in the `page` collection. Our home page doesn't currently have that. Long term we may want to make this more robust (specify either URL or page object per-menu item), then possibly refactor the footer to use that.