### PR TITLE
Video editor component

### DIFF
--- a/_pages/home/index.md
+++ b/_pages/home/index.md
@@ -1,6 +1,8 @@
 ---
 title: Home
 public: true
+expires_at: ""
 ---
-
 This is the home page!
+
+{::video url="https://www.youtube.com/watch?v=SAK117AmzSE" alt="" /}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,6 +6,10 @@ class PagesController < ApplicationController
     policy.connect_src :self, :blob
   end
 
+  content_security_policy do |policy|
+    policy.frame_src "https://www.youtube-nocookie.com"
+  end
+
   def home
   end
 

--- a/app/javascript/VideoEditorComponent.jsx
+++ b/app/javascript/VideoEditorComponent.jsx
@@ -1,0 +1,66 @@
+import React from "react"
+
+const VIDEO_TYPES = [
+    {
+        id: "youtube",
+        // e.g. https://www.youtube.com/watch?v=SAK117AmzSE
+        pattern:"https:\\/\\/www.youtube.com\\/watch\\?v=[\\w\\d]+(&|$)",
+        generatePreview(url, alt) {
+            const u = new URL(url)
+            const videoId = u.searchParams.get("v");
+            const embedUrl = `https://www.youtube-nocookie.com/embed/${videoId}`;
+            return <iframe width="560" height="315" src={embedUrl} title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>;
+        }
+    }
+]
+
+export const VideoEditorComponent = {
+    id: "video",
+    label: "Video",
+    fields: [
+        {
+            name: "url",
+            label: "URL",
+            widget: "string",
+        },
+        {
+            name: "alt",
+            label: "Alt text",
+            widget: "string",
+        }
+
+    ],
+    pattern: /{::video url="(.*?)" alt=".*?" \/}/,
+    /**
+     * @param {string[]} match 
+     * @returns {{alt: string, url: string}}
+     */
+    fromBlock(match) {
+        return {
+            url: decodeURIComponent(match[1]),
+            alt: decodeURIComponent(match[2]),
+        }
+    },
+    /**
+     * 
+     * @param {{alt: string, url: string}} data 
+     */
+    toBlock({url, alt}) {
+        url = encodeURIComponent((url ?? "").trim())
+        alt = encodeURIComponent((alt ?? "").trim())
+        return `{::video url="${url}" alt="${alt}" /}`
+    },
+    toPreview({url, alt}) {
+        console.log(url, alt)
+        const provider = VIDEO_TYPES.find(({pattern}) => {
+            const rx = new RegExp(`^${pattern}$`, "i");
+            console.log(url, rx, rx.test(url))
+            return rx.test(url)
+        });
+        if (!provider) {
+            return <div>Unrecognized video url: {url}</div>
+        }
+        return provider.generatePreview(url, alt)
+    },
+}
+

--- a/app/javascript/VideoEditorComponent.jsx
+++ b/app/javascript/VideoEditorComponent.jsx
@@ -9,7 +9,7 @@ const VIDEO_TYPES = [
             const u = new URL(url)
             const videoId = u.searchParams.get("v");
             const embedUrl = `https://www.youtube-nocookie.com/embed/${videoId}`;
-            return <iframe width="560" height="315" src={embedUrl} title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>;
+            return <iframe width="560" height="315" src={embedUrl} title={alt} frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>;
         }
     }
 ]
@@ -37,8 +37,8 @@ export const VideoEditorComponent = {
      */
     fromBlock(match) {
         return {
-            url: decodeURIComponent(match[1]),
-            alt: decodeURIComponent(match[2]),
+            url: unescapeFromKramdownExtensionAttribute(match[1]),
+            alt: unescapeFromKramdownExtensionAttribute(match[2]),
         }
     },
     /**
@@ -46,9 +46,7 @@ export const VideoEditorComponent = {
      * @param {{alt: string, url: string}} data 
      */
     toBlock({url, alt}) {
-        url = encodeURIComponent((url ?? "").trim())
-        alt = encodeURIComponent((alt ?? "").trim())
-        return `{::video url="${url}" alt="${alt}" /}`
+        return `{::video url="${escapeForKramdownExtensionAttribute(url)}" alt="${escapeForKramdownExtensionAttribute(alt)}" /}`
     },
     toPreview({url, alt}) {
         console.log(url, alt)
@@ -60,7 +58,27 @@ export const VideoEditorComponent = {
         if (!provider) {
             return <div>Unrecognized video url: {url}</div>
         }
+
         return provider.generatePreview(url, alt)
     },
 }
 
+/**
+ * Escapes user input for storage in a Kramdown extension attribute.
+ * Note that this _does not_ do sanitization--that'll be the job of 
+ * whatever's rendering the Markdown to HTML.
+ * @param {any} input
+ * @returns {string}
+ */
+function escapeForKramdownExtensionAttribute(input) {
+    input = String(input ?? "");
+    return input.replace(/\"/g, "\\\"")
+}
+
+/**
+ * @param {any} value
+ * @returns {string}
+ */
+function unescapeFromKramdownExtensionAttribute(value) {
+    return String(value ?? "").replace(/\\"/g, '"');
+}

--- a/app/javascript/netlify-app.js
+++ b/app/javascript/netlify-app.js
@@ -1,6 +1,7 @@
 import CMS from 'netlify-cms-app'
 import { GitGatewayBackend } from 'netlify-cms-backend-git-gateway'
 import AuthenticationPage from './AuthenticationPage.jsx'
+import {VideoEditorComponent} from "./VideoEditorComponent.jsx"
 
 class NihGateway extends GitGatewayBackend {
   authComponent() {
@@ -9,4 +10,5 @@ class NihGateway extends GitGatewayBackend {
 }
 
 CMS.registerBackend('nih-gateway', NihGateway)
+CMS.registerEditorComponent(VideoEditorComponent)
 CMS.init()

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,3 +1,5 @@
+require "#{Rails.root}/lib/kramdown/parser/custom_parser"
+
 class Page
   def self.find_by_path(path, try_index = true)
     dirname = Pathname(path).dirname
@@ -109,7 +111,7 @@ class Page
   end
 
   def rendered_content
-    Kramdown::Document.new(parsed_file.content).to_html.html_safe
+    Kramdown::Document.new(parsed_file.content, input: "CustomParser").to_html.html_safe
   end
 
   class NotFound < StandardError; end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,5 +1,3 @@
-require "#{Rails.root}/lib/kramdown/parser/custom_parser"
-
 class Page
   def self.find_by_path(path, try_index = true)
     dirname = Pathname(path).dirname

--- a/lib/kramdown/parser/custom_parser.rb
+++ b/lib/kramdown/parser/custom_parser.rb
@@ -1,0 +1,96 @@
+# Custom Kramdown parser for
+class Kramdown::Parser::CustomParser < Kramdown::Parser::Kramdown
+  def handle_extension(name, opts, body, type, line = nil)
+    case name
+    when "video"
+      if handle_video opts, line
+        return true
+      end
+    end
+
+    super
+  end
+
+  def handle_video(opts, line)
+    [:build_youtube_embed, :build_error_embed].each do |build|
+      element = send build, opts["url"], opts["alt"], line
+      if element
+        @tree.children << element
+        return true
+      end
+    end
+
+    false
+  end
+
+  def build_error_embed(url, alt, line)
+    div = Element.new(
+      :html_element,
+      "div",
+      {
+        "class" => "video video--error"
+      },
+      category: :block,
+      content_model: :raw,
+      location: line
+    )
+    add_text "Invalid video URL: #{url}", div
+
+    div
+  end
+
+  def build_youtube_embed(url, alt, line)
+    embed_url = get_youtube_embed_url url
+
+    return unless embed_url
+
+    iframe = Element.new(
+      :html_element,
+      "iframe",
+      {
+        "width" => 560,
+        "height" => 315,
+        "src" => embed_url.to_s,
+        "title" => alt,
+        "frameborder" => 0,
+        "allow" => "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture",
+        "allowfullscreen" => true
+      }
+    )
+
+    wrapper = Element.new(
+      :html_element,
+      "div",
+      {
+        "class" => "video"
+      },
+      category: :block,
+      content_model: :raw,
+      location: line
+    )
+
+    wrapper.children << iframe
+
+    wrapper
+  end
+
+  def get_youtube_embed_url video_url
+    parsed = begin
+      URI.parse video_url
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    if parsed && parsed.host == "www.youtube.com"
+      params = CGI.parse parsed.query
+      video_id = params["v"].shift
+
+      if video_id
+        return URI.join "https://www.youtube-nocookie.com/embed/", video_id
+      end
+
+    end
+
+    nil
+  end
+end

--- a/spec/lib/kramdown/custom_parser_spec.rb
+++ b/spec/lib/kramdown/custom_parser_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-require "#{Rails.root}/lib/kramdown/parser/custom_parser"
 
 RSpec.describe "Custom Kramdown Parser" do
   describe "YouTube" do
@@ -57,7 +56,6 @@ RSpec.describe "Custom Kramdown Parser" do
     it "outputs an error message" do
       expect(element.value).to eql("div")
       expect(element.attr["class"]).to eql("video video--error")
-      puts element.inspect
     end
   end
 end

--- a/spec/lib/kramdown/custom_parser_spec.rb
+++ b/spec/lib/kramdown/custom_parser_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+require "#{Rails.root}/lib/kramdown/parser/custom_parser"
+
+RSpec.describe "Custom Kramdown Parser" do
+  describe "YouTube" do
+    let(:element) {
+      doc = Kramdown::Document.new(
+        "
+# Test
+
+{::video url=\"https://www.youtube.com/watch?v=SAK117AmzSE\" alt=\"This is the alt text\" /}
+        ".strip,
+        input: "CustomParser"
+      )
+
+      # doc.root.children.each { |c| puts c.inspect }
+      doc.root.children.find { |e| e.type == :html_element }
+    }
+
+    let(:iframe) {
+      element.children.first
+    }
+
+    it "puts iframe in a wrapper" do
+      expect(element.value).to eql("div")
+      expect(element.block?).to be_truthy
+      expect(element.attr["class"]).to eql("video")
+
+      expect(iframe.type).to eql(:html_element)
+      expect(iframe.value).to eql("iframe")
+    end
+
+    it "includes alt text as iframe title" do
+      expect(iframe.attr["title"]).to eql("This is the alt text")
+    end
+
+    it "embeds youtube using -nocookie domain" do
+      expect(iframe.attr["src"]).to eql("https://www.youtube-nocookie.com/embed/SAK117AmzSE")
+    end
+  end
+
+  describe "Other URLs" do
+    let(:element) {
+      doc = Kramdown::Document.new(
+        "
+  # Test
+
+  {::video url=\"https://www.example.org/my-video.m4v\" /}
+          ".strip,
+        input: "CustomParser"
+      )
+
+      # doc.root.children.each { |c| puts c.inspect }
+      doc.root.children.find { |e| e.type == :html_element }
+    }
+
+    it "outputs an error message" do
+      expect(element.value).to eql("div")
+      expect(element.attr["class"]).to eql("video video--error")
+      puts element.inspect
+    end
+  end
+end


### PR DESCRIPTION
A component for embedding a video player. Video blocks are stored in Markdown using [Kramdown extensions](https://kramdown.gettalong.org/quickref.html#extensions), e.g.:

```
{::video url="https://www.youtube.com/watch?v=SAK117AmzSE&t=3s" alt="alt text" /}
```

Things left to do:

- [x] Update CSP to allow Youtube embedding
- [x] Update rendering to actually output the correct embed code