### PR TITLE
Event list

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -2,10 +2,14 @@
   "defaults": {
     "standard": "WCAG2AA",
     "runners": ["axe"],
-    "hideElements": ".usa-nav__primary-item > .usa-accordion__button > span"
+    "hideElements": [
+      ".usa-nav__primary-item > .usa-accordion__button > span",
+      "iframe[src^=\"https://www.youtube\"]"
+    ]
   },
   "urls": [
     "http://localhost:3000",
+    "http://localhost:3000/events",
     "http://localhost:3000/public-page",
     "http://localhost:3000/404"
   ]

--- a/_events/2022215-event-in-the-past.md
+++ b/_events/2022215-event-in-the-past.md
@@ -1,0 +1,12 @@
+---
+title: Event in the past
+date:
+  month: 2
+  day: 15
+  year: 2022
+start: 10:00 AM
+end: 11:30 am
+---
+**This event occurs in the past. It should not show up in the event listing.**
+
+Deserunt quis ex aliquip do consequat cillum culpa veniam pariatur et. Lorem proident cillum officia velit anim nisi. Nisi anim aliqua minim esse incididunt. Commodo sit sunt dolor pariatur elit duis. Velit dolor sint sint ut duis fugiat ullamco do laboris eiusmod sint adipisicing reprehenderit. Pariatur sunt ex incididunt ea reprehenderit sunt.

--- a/_events/202253-another-event.md
+++ b/_events/202253-another-event.md
@@ -1,0 +1,14 @@
+---
+title: Another event
+date:
+  month: 5
+  day: 3
+  year: 2022
+start: 1:00 pm
+end: 3:00 pm
+speakers:
+  - name: Matt Hinz
+audience:
+  - NIH Staff Scientist/Staff Clinician
+---
+Velit ex eiusmod cupidatat dolor dolore. Qui commodo sint velit consectetur deserunt. Ex ipsum dolor consectetur amet sint qui Lorem proident. Non irure excepteur Lorem ullamco laborum laborum. Est ut dolor nulla eiusmod ad esse ullamco et id ex incididunt anim. Commodo amet aute incididunt sint velit adipisicing sunt ea non commodo Lorem non velit non. Aliquip voluptate esse veniam incididunt mollit esse duis ea laboris et et occaecat nulla sunt.

--- a/_events/2022712-event-further-in-the-future.md
+++ b/_events/2022712-event-further-in-the-future.md
@@ -1,0 +1,10 @@
+---
+title: Event further in the future
+date:
+  month: 7
+  day: 12
+  year: 2022
+start: 2:00 pm
+end: 3:00 pm
+---
+Occaecat qui velit ad ipsum labore eiusmod elit ullamco. Excepteur sit ad deserunt elit enim sit sunt deserunt voluptate nisi. Aute in enim pariatur ut minim sunt ut ad adipisicing amet deserunt eiusmod. Deserunt ullamco aliqua do sunt dolore ex aliquip.

--- a/_pages/events/index.md
+++ b/_pages/events/index.md
@@ -1,0 +1,8 @@
+---
+title: Events
+public: true
+expires_at: ""
+sidebar:
+  - block: hours-location/block
+---
+This is the events page. This preamble is editable in the CMS.

--- a/_settings/audiences.yml
+++ b/_settings/audiences.yml
@@ -1,0 +1,6 @@
+audiences:
+  - Summer Interns
+  - Postbacs
+  - Graduate Students
+  - Postdocs/Fellows
+  - NIH Staff Scientist/Staff Clinician

--- a/_settings/navigation.yml
+++ b/_settings/navigation.yml
@@ -1,6 +1,8 @@
 items:
   - page: home/index
     include_children: false
+  - page: events/index
+    include_children: false
   - page: wellness/index
     include_children: true
   - page: contact/index

--- a/_settings/navigation.yml
+++ b/_settings/navigation.yml
@@ -1,5 +1,7 @@
 items:
   - page: home/index
+    include_children: false
   - page: wellness/index
     include_children: true
   - page: contact/index
+    include_children: false

--- a/app/assets/stylesheets/application.postcss.css
+++ b/app/assets/stylesheets/application.postcss.css
@@ -2,6 +2,7 @@
 @import "uswds-settings.scss";
 @import "../../../node_modules/uswds/dist/scss/uswds.scss";
 @import "uswds-tweaks.scss";
+@import "video.scss";
 @import "netlify-preview.scss";
 
 .nih-sidebar {

--- a/app/assets/stylesheets/video.scss
+++ b/app/assets/stylesheets/video.scss
@@ -1,0 +1,15 @@
+@use "sass:math";
+
+.video {
+  // XXX: Assume 16:9 for all video.
+  padding-top: (math.div(9, 16) * 100%);
+  position: relative;
+
+  > iframe {
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
+}

--- a/app/controllers/concerns/video_embeddable.rb
+++ b/app/controllers/concerns/video_embeddable.rb
@@ -1,0 +1,9 @@
+module VideoEmbeddable
+  extend ActiveSupport::Concern
+
+  included do
+    content_security_policy do |policy|
+      policy.frame_src "https://www.youtube-nocookie.com"
+    end
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -22,7 +22,4 @@ class EventsController < ApplicationController
       nil
     end
   end
-
-  def view
-  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,28 @@
+class EventsController < ApplicationController
+  include VideoEmbeddable
+
+  def index
+    @audiences = Event.audiences
+
+    @selected_audiences = if params[:audience].nil? || params[:audience].size == 0
+      @audiences
+    else
+      params[:audience]
+    end
+
+    @events = Event.all.select { |event|
+      event.audiences.empty? || @selected_audiences.any? { |el|
+        event.audiences.include? el
+      }
+    }
+
+    @page = begin
+      Page.find_by_path "events"
+    rescue Page::NotFound
+      nil
+    end
+  end
+
+  def view
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,13 +1,11 @@
 class PagesController < ApplicationController
+  include VideoEmbeddable
+
   content_security_policy only: :netlify do |policy|
     policy.script_src :self, "'unsafe-eval'"
     policy.style_src :self, "'unsafe-inline'"
     policy.img_src :self, :data, :blob
     policy.connect_src :self, :blob
-  end
-
-  content_security_policy do |policy|
-    policy.frame_src "https://www.youtube-nocookie.com"
   end
 
   def home

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,13 @@
 // Entry point for the build script in your package.json
 
 import "uswds";
+
+// Auto-submit forms on element clicks
+document.addEventListener("click", (evt) => {
+  if (
+    evt.target instanceof HTMLElement &&
+    evt.target.hasAttribute("data-submit-form-on-click")
+  ) {
+    evt.target.form.submit();
+  }
+});

--- a/app/models/concerns/netlify_content.rb
+++ b/app/models/concerns/netlify_content.rb
@@ -3,8 +3,7 @@ module NetlifyContent
 
   class_methods do
     def all(base:)
-      puts base.inspect
-      Dir.glob(base.join("*.md")).map do |file|
+      Dir.glob("*.md", base: base).map do |file|
         full_path = base.join file
         new full_path, base: base
       end

--- a/app/models/concerns/netlify_content.rb
+++ b/app/models/concerns/netlify_content.rb
@@ -2,6 +2,14 @@ module NetlifyContent
   extend ActiveSupport::Concern
 
   class_methods do
+    def all(base:)
+      puts base.inspect
+      Dir.glob(base.join("*.md")).map do |file|
+        full_path = base.join file
+        new full_path, base: base
+      end
+    end
+
     def find_by_path(path, base:, try_index:)
       dirname = Pathname(path).dirname
       filename = Pathname(path).basename(".md")

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,25 @@
 class Event
   include NetlifyContent
 
+  def self.all(after: nil, base: Rails.root.join("_events"))
+    after ||= Date.today
+
+    events = super base: base
+
+    events = events.select { |event|
+      event.date >= after
+    }
+
+    events.sort_by! { |event| event.date }
+
+    events
+  end
+
+  def self.audiences(file = Rails.root.join("_settings/audiences.yml"))
+    data = YAML.safe_load File.read(file), fallback: {}
+    data["audiences"] || []
+  end
+
   def self.find_by_path(path, base: Rails.root.join("_events"), try_index: false)
     super path, base: base, try_index: try_index
   end
@@ -21,6 +40,14 @@ class Event
     end
   end
 
+  def start
+    date_with_time start_time
+  end
+
+  def end
+    date_with_time end_time
+  end
+
   def start_time
     parsed_file["start"].downcase
   end
@@ -38,6 +65,25 @@ class Event
   end
 
   private
+
+  def date_with_time(time)
+    m = /^(\d+)(?::(\d+))\s*(am|pm)$/i.match time
+    return date unless m
+
+    hour = m[1].to_i
+    minute = m[2] ? m[2].to_i : 0
+    ampm = m[3].downcase
+
+    hour += 12 if ampm == "pm"
+
+    Time.new(
+      date.year,
+      date.month,
+      date.day,
+      hour,
+      minute
+    )
+  end
 
   def speakers
     parsed_file["speakers"] || []

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -67,11 +67,10 @@ class Event
   private
 
   def date_with_time(time)
-    m = /^(\d+)(?::(\d+))\s*(am|pm)$/i.match time
-    return date unless m
+    m = /^(\d+):(\d+)\s*(am|pm)$/i.match time
 
     hour = m[1].to_i
-    minute = m[2] ? m[2].to_i : 0
+    minute = m[2].to_i
     ampm = m[3].downcase
 
     hour += 12 if ampm == "pm"

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,13 +6,7 @@ class Event
 
     events = super base: base
 
-    events = events.select { |event|
-      event.date >= after
-    }
-
-    events.sort_by! { |event| event.date }
-
-    events
+    events.select { |event| event.date >= after }.sort_by(&:date)
   end
 
   def self.audiences(file = Rails.root.join("_settings/audiences.yml"))

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,92 @@
+<div class="grid-row grid-gap">
+  <div class="grid-col-12">
+    <h1>Events</h1>
+    <% if @page %>
+      <%= @page.rendered_content %>
+    <% end %>
+  </div>
+</div>
+
+<div class="grid-row grid-gap">
+  <aside class="grid-col-12 desktop:grid-col-4">
+<%= form_with method: :get, class: "usa-form margin-x-auto margin-bottom-1" do |form| %>
+  <fieldset class="usa-fieldset">
+    <legend class="usa-legend"><h3>Filter by audience</h3></legend>
+    <% @audiences.each do |audience| %>
+      <%
+        is_selected = @selected_audiences.include?(audience)
+        is_only_one_selected = is_selected && @selected_audiences.size == 1
+      %>
+      <% if is_only_one_selected then %>
+        <% # We're disabling the checkbox, but we need to persist the value on form submit %>
+        <input type="hidden" name="audience[]" value="<%= audience %>">
+      <% end %>
+      <div class="usa-checkbox">
+        <input
+          class="usa-checkbox__input usa-checkbox__input--tile"
+          id="filter-<%= audience.parameterize %>"
+          type="checkbox"
+          name="audience[]"
+          value="<%= audience %>"
+          <%= if is_selected then "checked" end %>
+          <%= if is_only_one_selected then "disabled" end %>
+          data-submit-form-on-click
+        />
+        <label class="usa-checkbox__label" for="filter-<%= audience.parameterize %>">
+          <%= audience %>
+        </label>
+      </div>
+    <% end %>
+  </fieldset>
+<% end %>
+  </aside>
+  <div class="grid-col-12 desktop:grid-col-8">
+
+    <ul class="usa-collection oite-events">
+      <% @events.each do |event| %>
+        <li class="usa-collection__item oite-event">
+          <div class="usa-collection__calendar-date">
+            <time datetime="<%= event.date %>">
+              <span class="usa-collection__calendar-date-month"><%= event.date.strftime("%b").upcase %></span>
+              <span class="usa-collection__calendar-date-day"><%= event.date.strftime("%d") %></span>
+            </time>
+          </div>
+          <div class="usa-collection__body">
+            <div class="usa-collection__heading">
+              <h3 class="margin-0">
+                <%= event.title %>
+              </h3>
+              <div class="oite-event__time text-italic">
+                <time datetime="<%= event.start.strftime("%F") %>"><%= event.start.strftime("%A, %B %-d, %Y %l:%M %p") %></time>
+                –
+                <time datetime="<%= event.end.strftime("%F") %>"><%= event.end.strftime("%l:%M %p") %></time>
+              </div>
+            </div>
+            <div class="usa-collection__description">
+              <% unless event.speaker_names.empty? %>
+                <div class="oite-event__speakers margin-y-1">
+                  <h4 class="margin-0">Speakers</h4>
+                  <ul class="usa-list">
+                    <% event.speaker_names.each do |speaker| %>
+                    <li>
+                      <%= speaker%>
+                    </li>
+                    <% end %>
+                  </ul>
+                </div>
+              <% end %>
+              <div class="usa-prose p-summary">
+                <%= event.rendered_content%>
+              </div>
+              <div class="oite-event__audiences margin-y-1">
+                <% event.audiences.each do |audience| %>
+
+                      <a class="usa-button usa-button--accent-cool text-bold text-uppercase font-ui-2xs" href="<%= events_page_url :audience => [audience] %>"><%= audience %></a>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -80,8 +80,7 @@
               </div>
               <div class="oite-event__audiences margin-y-1">
                 <% event.audiences.each do |audience| %>
-
-                      <a class="usa-button usa-button--accent-cool text-bold text-uppercase font-ui-2xs" href="<%= events_page_url :audience => [audience] %>"><%= audience %></a>
+                  <%= link_to audience, events_page_url(audience: [audience]), class: "usa-button usa-button--accent-cool text-bold text-uppercase font-ui-2xs" %>
                 <% end %>
               </div>
             </div>

--- a/app/views/pages/netlify_config.yaml.erb
+++ b/app/views/pages/netlify_config.yaml.erb
@@ -52,12 +52,7 @@ collections:
         widget: "select"
         required: false
         multiple: true
-        options:
-          - Summer Interns
-          - Postbacs
-          - Graduate Students
-          - Postdocs/Fellows
-          - NIH Staff Scientist/Staff Clinician
+        options: <%= raw JSON.generate(Event.audiences) %>
       - {label: "Description", name: "body", widget: "markdown"}
 <% end %>
 <% if policy(:netlify).cms? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,8 @@ Rails.application.routes.draw do
 
   root "pages#home"
 
+  get "events/", to: "events#index", as: :events_page
+
   get "*path", to: "pages#page", as: :content_page
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe EventsController do
+  before {
+    allow(Rails).to receive(:root).and_return(file_fixture("_pages").join("..").cleanpath)
+    allow(Date).to receive(:today).and_return(Date.new(2022, 4, 4))
+  }
+
+  it "shows events for all audiences by default" do
+    get :index
+    expect(assigns(:selected_audiences)).to eq(["Summer Interns", "Postbacs", "Graduate Students", "Postdocs/Fellows", "NIH Staff Scientist/Staff Clinician"])
+  end
+
+  it "does not show events in the past" do
+    get :index
+    expect(assigns(:events)).not_to be_nil
+    expect(assigns(:events)).not_to be_empty
+    expect(assigns(:events)).to all satisfy { |ev|
+      ev.date >= Date.new(2022, 4, 4)
+    }
+  end
+
+  it "can be filtered by audience" do
+    request.params[:selected_audiences] = ["Summer Interns"]
+    get :index
+    expect(assigns(:events)).not_to be_nil
+    expect(assigns(:events)).not_to be_empty
+
+    expect(assigns(:events)).to all satisfy { |ev|
+      ev.audiences.empty? || ev.audiences.include?("Summer Interns")
+    }
+  end
+end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -30,4 +30,10 @@ RSpec.describe EventsController do
       ev.audiences.empty? || ev.audiences.include?("Summer Interns")
     }
   end
+
+  it "picks up content from the /events page" do
+    get :index
+    expect(assigns(:page)).not_to be_nil
+    expect(assigns(:page)).to have_attributes filename: Pathname.new("events")
+  end
 end

--- a/spec/fixtures/files/_events/202221-event-in-the-past.md
+++ b/spec/fixtures/files/_events/202221-event-in-the-past.md
@@ -1,0 +1,10 @@
+---
+title: Training Event
+date:
+  month: 2
+  day: 1
+  year: 2022
+start: 9:30 AM
+end: 11:00 am
+---
+This event happened in the past, from the perspective of the test suite.

--- a/spec/fixtures/files/_pages/events/index.md
+++ b/spec/fixtures/files/_pages/events/index.md
@@ -1,0 +1,4 @@
+---
+title: Events
+---
+This is content that is displayed on the "Events" page.

--- a/spec/fixtures/files/_settings/audiences.yml
+++ b/spec/fixtures/files/_settings/audiences.yml
@@ -1,0 +1,6 @@
+audiences:
+  - Summer Interns
+  - Postbacs
+  - Graduate Students
+  - Postdocs/Fellows
+  - NIH Staff Scientist/Staff Clinician

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe "#start" do
+    it "returns the date combined with the start time for the event" do
+      expect(subject.start).to eq Time.new(2022, 5, 7, 9, 30)
+    end
+  end
+
+  describe "#end" do
+    it "returns the date combined with the end time for the event" do
+      expect(subject.end).to eq Time.new(2022, 5, 7, 11, 0)
+    end
+  end
+
   describe "#speaker_names" do
     it "returns a list of speaker names" do
       expect(subject.speaker_names).to eq ["Ryan Ahearn, Esq"]

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -39,17 +39,18 @@ RSpec.describe Page, type: :model do
     it "builds a hierarchy" do
       h = described_class.build_hierarchy(file_fixture("_pages").cleanpath)
 
-      expect(h.length).to eql(3)
+      expect(h.length).to eql(4)
 
       expect(h[0].title).to eql("Root File")
-      expect(h[1].title).to eql("Page One")
-      expect(h[2].title).to eql("Page Two")
+      expect(h[1].title).to eql("Events")
+      expect(h[2].title).to eql("Page One")
+      expect(h[3].title).to eql("Page Two")
 
-      expect(h[1].children.length).to eql(1)
-      expect(h[2].children.length).to eql(0)
+      expect(h[2].children.length).to eql(1)
+      expect(h[3].children.length).to eql(0)
 
-      expect(h[1].children[0].title).to eql("Child One")
-      expect(h[1].children[0].children[0].title).to eql("Child Two")
+      expect(h[2].children[0].title).to eql("Child One")
+      expect(h[2].children[0].children[0].title).to eql("Child Two")
     end
   end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "Events", type: :request do
+  describe "GET /events" do
+    it "returns http success" do
+      get "/events"
+      expect(response).to render_template :index
+    end
+  end
+end

--- a/zap.conf
+++ b/zap.conf
@@ -119,3 +119,5 @@
 90030	WARN	(WSDL File Detection - Passive/alpha)
 90033	WARN	(Loosely Scoped Cookie - Passive/release)
 90034	WARN	(Cloud Metadata Potentially Exposed - Active/beta)
+10202	OUTOFSCOPE	http://.*:3000/events.*
+20012	OUTOFSCOPE	http://.*:3000/events.*


### PR DESCRIPTION
<img width="1101" alt="image" src="https://user-images.githubusercontent.com/364697/161355457-01b0e6ab-17a7-4a5f-86ea-9c814af070df.png">

Work in progress on event listing page. See [Trello](https://trello.com/c/Tk6NVBEF/164-oite-event-creator-create-event-listing-for-specific-audiences)

## Things this does

- Attempts to make the "preamble" section on the events page editable in the CMS by looking up the corresponding `Page` model for `/events`
- Lists all events that _have not happened yet_, without pagination
- Uses some slightly janky, very MVP checkboxes for filtering, probably will want a consult with @dluetger and @michelle-rago about what filtering / searching options we'll want to prototype & test.
