### PR TITLE
Fix regex to parse alt text back to editor component

### DIFF
--- a/app/javascript/VideoEditorComponent.jsx
+++ b/app/javascript/VideoEditorComponent.jsx
@@ -59,7 +59,7 @@ const VideoEditorComponent = {
       widget: "string",
     },
   ],
-  pattern: /{::video url="(.*?)" alt=".*?" \/}/,
+  pattern: /{::video url="(.*)" alt="(.*)" \/}/,
   /**
    * @param {string[]} match
    * @returns {{alt: string, url: string}}

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -33,7 +33,7 @@ class Page
     md_files = []
     index_md = nil
 
-    Dir.each_child(dir) do |f|
+    Dir.each_child(dir).sort.each do |f|
       full_path = dir.join(f)
 
       if File.directory? full_path


### PR DESCRIPTION
Needed to add the match group for alt text.

I also removed the `?` from each group, because I don't _think_ they're necessary. Quick test worked, but is there another reasons it's needed?