### PR TITLE
Content block editor component

### DIFF
--- a/_pages/home/index.md
+++ b/_pages/home/index.md
@@ -6,3 +6,5 @@ expires_at: ""
 This is the home page!
 
 {::video url="https://www.youtube.com/watch?v=SAK117AmzSE" alt="" /}
+
+{::content_block slug="hours-location/block" /}

--- a/app/javascript/ContentBlockEditorComponent.jsx
+++ b/app/javascript/ContentBlockEditorComponent.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import createKramdownExtensionEditorComponent from "./kramdown";
+
+const ContentBlockEditorComponent = createKramdownExtensionEditorComponent({
+  id: "content_block",
+  label: "Content block",
+  fields: [
+    {
+      name: "slug",
+      label: "Block",
+      widget: "relation",
+      collection: "block",
+      search_fields: ["name", "{{slug}}"],
+      value_field: "{{slug}}",
+      display_fields: ["name"],
+    },
+  ],
+  toPreview: ({ slug }) => (
+    <div className="bg-base-lighter padding-1">
+      Content block: <code>{slug}</code>
+    </div>
+  ),
+});
+
+export default ContentBlockEditorComponent;

--- a/app/javascript/VideoEditorComponent.jsx
+++ b/app/javascript/VideoEditorComponent.jsx
@@ -11,15 +11,17 @@ const VIDEO_TYPES = [
       const videoId = u.searchParams.get("v");
       const embedUrl = `https://www.youtube-nocookie.com/embed/${videoId}`;
       return (
-        <iframe
-          width="560"
-          height="315"
-          src={embedUrl}
-          title={alt}
-          frameBorder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowFullScreen
-        />
+        <div className="video">
+          <iframe
+            width="560"
+            height="315"
+            src={embedUrl}
+            title={alt}
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          />
+        </div>
       );
     },
   },

--- a/app/javascript/VideoEditorComponent.jsx
+++ b/app/javascript/VideoEditorComponent.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import createKramdownExtensionEditorComponent from "./kramdown";
 
 const VIDEO_TYPES = [
   {
@@ -27,26 +28,7 @@ const VIDEO_TYPES = [
   },
 ];
 
-/**
- * Escapes user input for storage in a Kramdown extension attribute.
- * Note that this _does not_ do sanitization--that'll be the job of
- * whatever's rendering the Markdown to HTML.
- * @param {any} input
- * @returns {string}
- */
-function escapeForKramdownExtensionAttribute(input) {
-  return String(input ?? "").replace(/"/g, '\\"');
-}
-
-/**
- * @param {any} value
- * @returns {string}
- */
-function unescapeFromKramdownExtensionAttribute(value) {
-  return String(value ?? "").replace(/\\"/g, '"');
-}
-
-const VideoEditorComponent = {
+const VideoEditorComponent = createKramdownExtensionEditorComponent({
   id: "video",
   label: "Video",
   fields: [
@@ -61,26 +43,6 @@ const VideoEditorComponent = {
       widget: "string",
     },
   ],
-  pattern: /{::video url="(.*)" alt="(.*)" \/}/,
-  /**
-   * @param {string[]} match
-   * @returns {{alt: string, url: string}}
-   */
-  fromBlock(match) {
-    return {
-      url: unescapeFromKramdownExtensionAttribute(match[1]),
-      alt: unescapeFromKramdownExtensionAttribute(match[2]),
-    };
-  },
-  /**
-   *
-   * @param {{alt: string, url: string}} data
-   */
-  toBlock({ url, alt }) {
-    return `{::video url="${escapeForKramdownExtensionAttribute(
-      url
-    )}" alt="${escapeForKramdownExtensionAttribute(alt)}" /}`;
-  },
   toPreview({ url, alt }) {
     const provider = VIDEO_TYPES.find(({ pattern }) => {
       const rx = new RegExp(`^${pattern}$`, "i");
@@ -92,6 +54,6 @@ const VideoEditorComponent = {
 
     return provider.generatePreview(url, alt);
   },
-};
+});
 
 export default VideoEditorComponent;

--- a/app/javascript/kramdown.jsx
+++ b/app/javascript/kramdown.jsx
@@ -1,0 +1,112 @@
+import React from "react";
+
+/**
+ * Escapes user input for storage in a Kramdown extension attribute.
+ * Note that this _does not_ do sanitization--that'll be the job of
+ * whatever's rendering the Markdown to HTML.
+ * @param {any} input
+ * @returns {string}
+ */
+function escapeForExtensionAttribute(input) {
+  return String(input ?? "").replace(/"/g, '\\"');
+}
+
+/**
+ * @param {any} value
+ * @returns {string}
+ */
+function unescapeExtensionAttribute(value) {
+  return String(value ?? "").replace(/\\"/g, '"');
+}
+
+/**
+ * Generates a regular expression that will match a Kramdown extension, e.g.:
+ *
+ * ```
+ * {::some_tag attr="value" otherAttr="value" /}
+ * ```
+ *
+ * @param {name} {string}
+ * @param {attrNames} {string[]} Names of attributes expected (in order)
+ * @returns {RegExp} A regular expression that will match a kramdown extension tag.
+ */
+function makeExtensionRegex(name, attrNames) {
+  // NOTE: This pattern is quite fragile and depends on exact ordering of attributes.
+  const attrPatterns = attrNames
+    .map((attrName) => `${attrName}="(.*)"`)
+    .join(" ");
+  return new RegExp(`{::${name}${attrPatterns ? ` ${attrPatterns}` : ""} \\/}`);
+}
+
+/**
+ * Creates a Netlify Markdown editor component that is represented in markdown
+ * using Kramdown's extension syntax.
+ * @param options {Object}
+ * @param options.id {string}
+ * @param options.label {string}
+ * @param options.fields {{name: string, label: string, widget: string, [key: string]: any}[]} Fields supported by the component. (Order matters here)
+ * @param options.toPreview {(data: any) => React.ReactElement}
+ * @returns {{
+ *  id: string,
+ *  label: string,
+ *  fields: {name: string, label: string, widget: string; [key: string]: any},
+ *  pattern: RegExp,
+ *  fromBlock: (match: string[]) => Record<string,any>,
+ *  toBlock: (data: Record<string,any>) => string,
+ *  toPreview: (data: Record<string,any>) => React.ReactNode
+ * }}
+ */
+export default function createKramdownExtensionEditorComponent(options) {
+  const fields = options.fields ?? [];
+
+  const pattern = makeExtensionRegex(
+    options.id,
+    fields.map((f) => f.name)
+  );
+
+  // Convert a regex match back to an object whose keys are the field names and values are the field values
+  const fromBlock = (match) =>
+    fields.reduce(
+      (result, field, index) => ({
+        ...result,
+        [field.name]: unescapeExtensionAttribute(match[index + 1]),
+      }),
+      {}
+    );
+
+  // Convert attribute values into the Markdown representation
+  const toBlock = (data) =>
+    [
+      `{::${options.id}`,
+      ...fields.map(
+        (f) => `${f.name}="${escapeForExtensionAttribute(data[f.name] ?? "")}"`
+      ),
+      `/}`,
+    ].join(" ");
+
+  const toPreview =
+    options.toPreview ??
+    ((data) => (
+      <div>
+        <strong>{options.id}</strong>
+        {fields.length && (
+          <ul>
+            {fields.map((f) => (
+              <li key={f.name}>
+                {f.label} = {data[f.name]}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    ));
+
+  return {
+    ...options,
+    fields,
+    pattern,
+    fromBlock,
+    toBlock,
+    toPreview,
+  };
+}

--- a/app/javascript/kramdown.jsx
+++ b/app/javascript/kramdown.jsx
@@ -49,7 +49,7 @@ function makeExtensionRegex(name, attrNames) {
  * @returns {{
  *  id: string,
  *  label: string,
- *  fields: {name: string, label: string, widget: string; [key: string]: any},
+ *  fields: {name: string, label: string, widget: string; [key: string]: any}[],
  *  pattern: RegExp,
  *  fromBlock: (match: string[]) => Record<string,any>,
  *  toBlock: (data: Record<string,any>) => string,

--- a/app/javascript/netlify-app.js
+++ b/app/javascript/netlify-app.js
@@ -1,6 +1,7 @@
 import CMS from "netlify-cms-app";
 import { GitGatewayBackend } from "netlify-cms-backend-git-gateway";
 import AuthenticationPage from "./AuthenticationPage";
+import ContentBlockEditorComponent from "./ContentBlockEditorComponent";
 import VideoEditorComponent from "./VideoEditorComponent";
 
 class NihGateway extends GitGatewayBackend {
@@ -19,5 +20,6 @@ class NihGateway extends GitGatewayBackend {
   });
 
 CMS.registerBackend("nih-gateway", NihGateway);
+CMS.registerEditorComponent(ContentBlockEditorComponent);
 CMS.registerEditorComponent(VideoEditorComponent);
 CMS.init();

--- a/app/models/concerns/netlify_content.rb
+++ b/app/models/concerns/netlify_content.rb
@@ -23,6 +23,16 @@ module NetlifyContent
       end
     end
 
+    def find_by_slug(slug, base:)
+      full_path = Pathname(base).join "#{slug}.md"
+      if File.exist?(full_path)
+        new full_path, base: base
+      else
+        Rails.logger.error "Failed to find NetlifyContent path: #{full_path}"
+        fail NotFound
+      end
+    end
+
     def has_field(*fields, default: nil)
       fields.each do |field_name|
         define_method field_name do
@@ -36,8 +46,12 @@ module NetlifyContent
     attr_reader :parsed_file
   end
 
+  def content_document
+    Kramdown::Document.new(parsed_file.content, input: "CustomParser")
+  end
+
   def rendered_content
-    Kramdown::Document.new(parsed_file.content, input: "CustomParser").to_html.html_safe
+    content_document.to_html.html_safe
   end
 
   class NotFound < StandardError; end

--- a/app/models/concerns/netlify_content.rb
+++ b/app/models/concerns/netlify_content.rb
@@ -23,16 +23,6 @@ module NetlifyContent
       end
     end
 
-    def find_by_slug(slug, base:)
-      full_path = Pathname(base).join "#{slug}.md"
-      if File.exist?(full_path)
-        new full_path, base: base
-      else
-        Rails.logger.error "Failed to find NetlifyContent path: #{full_path}"
-        fail NotFound
-      end
-    end
-
     def has_field(*fields, default: nil)
       fields.each do |field_name|
         define_method field_name do

--- a/app/models/content_block.rb
+++ b/app/models/content_block.rb
@@ -5,6 +5,10 @@ class ContentBlock
     super path, base: base, try_index: try_index
   end
 
+  def self.find_by_slug(slug, base: Rails.root.join("_blocks"))
+    super slug, base: base
+  end
+
   has_field :name
 
   def initialize(path, base: nil)

--- a/app/models/content_block.rb
+++ b/app/models/content_block.rb
@@ -5,10 +5,6 @@ class ContentBlock
     super path, base: base, try_index: try_index
   end
 
-  def self.find_by_slug(slug, base: Rails.root.join("_blocks"))
-    super slug, base: base
-  end
-
   has_field :name
 
   def initialize(path, base: nil)

--- a/lib/kramdown/parser/custom_parser.rb
+++ b/lib/kramdown/parser/custom_parser.rb
@@ -1,96 +1,14 @@
-# Custom Kramdown parser for
+require_relative "extensions/video"
+
 class Kramdown::Parser::CustomParser < Kramdown::Parser::Kramdown
+  include CustomParserExtensions
+
   def handle_extension(name, opts, body, type, line = nil)
-    case name
-    when "video"
-      if handle_video opts, line
-        return true
-      end
-    end
-
-    super
-  end
-
-  def handle_video(opts, line)
-    [:build_youtube_embed, :build_error_embed].each do |build|
-      element = send build, opts["url"], opts["alt"], line
-      if element
-        @tree.children << element
-        return true
-      end
+    handler = "handle_#{name}_extension"
+    if respond_to? handler
+      return send handler, opts, body, type, line
     end
 
     false
-  end
-
-  def build_error_embed(url, alt, line)
-    div = Element.new(
-      :html_element,
-      "div",
-      {
-        "class" => "video video--error"
-      },
-      category: :block,
-      content_model: :raw,
-      location: line
-    )
-    add_text "Invalid video URL: #{url}", div
-
-    div
-  end
-
-  def build_youtube_embed(url, alt, line)
-    embed_url = get_youtube_embed_url url
-
-    return unless embed_url
-
-    iframe = Element.new(
-      :html_element,
-      "iframe",
-      {
-        "width" => 560,
-        "height" => 315,
-        "src" => embed_url.to_s,
-        "title" => alt,
-        "frameborder" => 0,
-        "allow" => "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture",
-        "allowfullscreen" => true
-      }
-    )
-
-    wrapper = Element.new(
-      :html_element,
-      "div",
-      {
-        "class" => "video"
-      },
-      category: :block,
-      content_model: :raw,
-      location: line
-    )
-
-    wrapper.children << iframe
-
-    wrapper
-  end
-
-  def get_youtube_embed_url video_url
-    parsed = begin
-      URI.parse video_url
-    rescue URI::InvalidURIError
-      nil
-    end
-
-    if parsed && parsed.host == "www.youtube.com"
-      params = CGI.parse parsed.query
-      video_id = params["v"].shift
-
-      if video_id
-        return URI.join "https://www.youtube-nocookie.com/embed/", video_id
-      end
-
-    end
-
-    nil
   end
 end

--- a/lib/kramdown/parser/custom_parser.rb
+++ b/lib/kramdown/parser/custom_parser.rb
@@ -1,7 +1,11 @@
+require_relative "extensions/content_block"
 require_relative "extensions/video"
 
 class Kramdown::Parser::CustomParser < Kramdown::Parser::Kramdown
   include CustomParserExtensions
+
+  # Add support for new types of Kramdown extensions by implementing a handler:
+  #  def handle_tagname_extension(name, opts, body, type, line)
 
   def handle_extension(name, opts, body, type, line = nil)
     handler = "handle_#{name}_extension"

--- a/lib/kramdown/parser/extensions/content_block.rb
+++ b/lib/kramdown/parser/extensions/content_block.rb
@@ -1,7 +1,7 @@
 module CustomParserExtensions
   def handle_content_block_extension(opts, body, type, line)
     block = begin
-      ContentBlock.find_by_slug opts["slug"]
+      ContentBlock.find_by_path opts["slug"]
     rescue ContentBlock::NotFound
       nil
     end

--- a/lib/kramdown/parser/extensions/content_block.rb
+++ b/lib/kramdown/parser/extensions/content_block.rb
@@ -1,0 +1,34 @@
+module CustomParserExtensions
+  def handle_content_block_extension(opts, body, type, line)
+    block = begin
+      ContentBlock.find_by_slug opts["slug"]
+    rescue ContentBlock::NotFound
+      nil
+    end
+
+    if block
+
+      block_class = opts["slug"].parameterize.gsub(/-block$/, "")
+
+      element = Kramdown::Element.new(
+        :html_element,
+        "div",
+        {
+          "class" => "content-block content-block--#{block_class}"
+        },
+        category: :block,
+        location: line
+      )
+      element.children << block.content_document.root
+    else
+      # No block found
+      element = Kramdown::Element.new(
+        :comment,
+        "Content block not found: #{opts["slug"]}"
+      )
+    end
+
+    @tree.children << element
+    true
+  end
+end

--- a/lib/kramdown/parser/extensions/video.rb
+++ b/lib/kramdown/parser/extensions/video.rb
@@ -1,0 +1,80 @@
+module CustomParserExtensions
+  def handle_video_extension(opts, body, type, line)
+    [:build_youtube_embed, :build_video_error_embed].each do |build|
+      element = send build, opts["url"], opts["alt"], line
+      if element
+        @tree.children << element
+        return true
+      end
+    end
+
+    false
+  end
+
+  def build_video_error_embed(url, alt, line)
+    div = Kramdown::Element.new(
+      :html_element,
+      "div",
+      {
+        "class" => "video video--error"
+      },
+      category: :block,
+      content_model: :raw,
+      location: line
+    )
+    add_text "Invalid video URL: #{url}", div
+
+    div
+  end
+
+  def build_youtube_embed(url, alt, line)
+    embed_url = get_youtube_embed_url url
+
+    return unless embed_url
+
+    iframe = Kramdown::Element.new(
+      :html_element,
+      "iframe",
+      {
+        "width" => 560,
+        "height" => 315,
+        "src" => embed_url.to_s,
+        "title" => alt,
+        "frameborder" => 0,
+        "allow" => "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture",
+        "allowfullscreen" => true
+      }
+    )
+
+    wrapper = Kramdown::Element.new(
+      :html_element,
+      "div",
+      {
+        "class" => "video"
+      },
+      category: :block,
+      content_model: :raw,
+      location: line
+    )
+
+    wrapper.children << iframe
+
+    wrapper
+  end
+
+  def get_youtube_embed_url video_url
+    parsed = begin
+      URI.parse video_url
+    rescue URI::InvalidURIError
+      nil
+    end
+    if parsed && parsed.host == "www.youtube.com"
+      params = CGI.parse parsed.query
+      video_id = params["v"].shift
+
+      if video_id
+        URI.join "https://www.youtube-nocookie.com/embed/", video_id
+      end
+    end
+  end
+end

--- a/spec/lib/kramdown/custom_parser_spec.rb
+++ b/spec/lib/kramdown/custom_parser_spec.rb
@@ -1,61 +1,121 @@
 require "rails_helper"
 
 RSpec.describe "Custom Kramdown Parser" do
-  describe "YouTube" do
+  describe "Video Embeds" do
+    describe "YouTube" do
+      let(:element) {
+        doc = Kramdown::Document.new(
+          "
+  # Test
+
+  {::video url=\"https://www.youtube.com/watch?v=SAK117AmzSE\" alt=\"This is the alt text\" /}
+          ".strip,
+          input: "CustomParser"
+        )
+
+        # doc.root.children.each { |c| puts c.inspect }
+        doc.root.children.find { |e| e.type == :html_element }
+      }
+
+      let(:iframe) {
+        element.children.first
+      }
+
+      it "puts iframe in a wrapper" do
+        expect(element.value).to eql("div")
+        expect(element.block?).to be_truthy
+        expect(element.attr["class"]).to eql("video")
+
+        expect(iframe.type).to eql(:html_element)
+        expect(iframe.value).to eql("iframe")
+      end
+
+      it "includes alt text as iframe title" do
+        expect(iframe.attr["title"]).to eql("This is the alt text")
+      end
+
+      it "embeds youtube using -nocookie domain" do
+        expect(iframe.attr["src"]).to eql("https://www.youtube-nocookie.com/embed/SAK117AmzSE")
+      end
+    end
+
+    describe "Other URLs" do
+      let(:element) {
+        doc = Kramdown::Document.new(
+          "
+# Test
+
+{::video url=\"https://www.example.org/my-video.m4v\" /}
+            ".strip,
+          input: "CustomParser"
+        )
+
+        # doc.root.children.each { |c| puts c.inspect }
+        doc.root.children.find { |e| e.type == :html_element }
+      }
+
+      it "outputs an error message" do
+        expect(element.value).to eql("div")
+        expect(element.attr["class"]).to eql("video video--error")
+      end
+    end
+  end
+
+  describe "Content Blocks" do
     let(:element) {
       doc = Kramdown::Document.new(
         "
 # Test
 
-{::video url=\"https://www.youtube.com/watch?v=SAK117AmzSE\" alt=\"This is the alt text\" /}
-        ".strip,
+{::content_block slug=\"hours-location/block\" /}
+          ".strip,
         input: "CustomParser"
       )
-
-      # doc.root.children.each { |c| puts c.inspect }
       doc.root.children.find { |e| e.type == :html_element }
     }
 
-    let(:iframe) {
-      element.children.first
+    let(:not_found_element) {
+      doc = Kramdown::Document.new(
+        "
+# Test
+
+{::content_block slug=\"block-that-does-not/exist\" /}
+            ".strip,
+        input: "CustomParser"
+      )
+      doc.root.children.find { |e| e.type == :comment }
     }
 
-    it "puts iframe in a wrapper" do
+    it "embeds a known content block" do
+      expect(element).to be_truthy
       expect(element.value).to eql("div")
-      expect(element.block?).to be_truthy
-      expect(element.attr["class"]).to eql("video")
-
-      expect(iframe.type).to eql(:html_element)
-      expect(iframe.value).to eql("iframe")
+      expect(element.attr["class"]).to eql("content-block content-block--hours-location")
     end
 
-    it "includes alt text as iframe title" do
-      expect(iframe.attr["title"]).to eql("This is the alt text")
-    end
-
-    it "embeds youtube using -nocookie domain" do
-      expect(iframe.attr["src"]).to eql("https://www.youtube-nocookie.com/embed/SAK117AmzSE")
+    it "inserts a comment when content block not found" do
+      expect(not_found_element).to be_truthy
+      expect(not_found_element.value).to eql("Content block not found: block-that-does-not/exist")
     end
   end
 
-  describe "Other URLs" do
+  describe "Unknown extensions" do
     let(:element) {
       doc = Kramdown::Document.new(
         "
-  # Test
+# Test
 
-  {::video url=\"https://www.example.org/my-video.m4v\" /}
+{::unknown_tag attr=\"value\" /}
           ".strip,
         input: "CustomParser"
       )
 
-      # doc.root.children.each { |c| puts c.inspect }
-      doc.root.children.find { |e| e.type == :html_element }
+      doc.root.children.find { |el| el.type == :p }
     }
 
-    it "outputs an error message" do
-      expect(element.value).to eql("div")
-      expect(element.attr["class"]).to eql("video video--error")
+    it "leaves unknown Kramdown extensions in the text" do
+      expect(element).to be_truthy
+      expect(element.children[0].type).to eql(:text)
+      expect(element.children[0].value).to start_with("{::unknown_tag attr=")
     end
   end
 end


### PR DESCRIPTION
Add a Markdown editor component for embedding an existing content block.

<img width="845" alt="Content block editor component" src="https://user-images.githubusercontent.com/364697/162278548-99cda6fa-5f72-44c4-a5f2-aac057dcaf20.png">


Closes https://trello.com/c/EkSdYXfk/192-cms-content-block-enhancement