### PR TITLE
Add topic to events

### DIFF
--- a/_blocks/no-events-found/block.md
+++ b/_blocks/no-events-found/block.md
@@ -1,0 +1,6 @@
+---
+name: No events found
+---
+## No events found
+
+No events matched your criteria.

--- a/_events/2022215-event-in-the-past.md
+++ b/_events/2022215-event-in-the-past.md
@@ -6,6 +6,7 @@ date:
   year: 2022
 start: 10:00 AM
 end: 11:30 am
+topic: []
 ---
 **This event occurs in the past. It should not show up in the event listing.**
 

--- a/_events/202253-another-event.md
+++ b/_events/202253-another-event.md
@@ -10,5 +10,7 @@ speakers:
   - name: Matt Hinz
 audience:
   - NIH Staff Scientist/Staff Clinician
+topic:
+  - Language Skills
 ---
 Velit ex eiusmod cupidatat dolor dolore. Qui commodo sint velit consectetur deserunt. Ex ipsum dolor consectetur amet sint qui Lorem proident. Non irure excepteur Lorem ullamco laborum laborum. Est ut dolor nulla eiusmod ad esse ullamco et id ex incididunt anim. Commodo amet aute incididunt sint velit adipisicing sunt ea non commodo Lorem non velit non. Aliquip voluptate esse veniam incididunt mollit esse duis ea laboris et et occaecat nulla sunt.

--- a/_events/202257-training-event.md
+++ b/_events/202257-training-event.md
@@ -14,6 +14,8 @@ audience:
 accommodations:
   name: Ryan Ahearn
   email: ryan.ahearn@gsa.gov
+topic:
+  - Management
 ---
 This is the **formatted** description of the training event.
 

--- a/_events/2022712-event-further-in-the-future.md
+++ b/_events/2022712-event-further-in-the-future.md
@@ -6,5 +6,6 @@ date:
   year: 2022
 start: 2:00 pm
 end: 3:00 pm
+topic: []
 ---
 Occaecat qui velit ad ipsum labore eiusmod elit ullamco. Excepteur sit ad deserunt elit enim sit sunt deserunt voluptate nisi. Aute in enim pariatur ut minim sunt ut ad adipisicing amet deserunt eiusmod. Deserunt ullamco aliqua do sunt dolore ex aliquip.

--- a/_settings/topics.yml
+++ b/_settings/topics.yml
@@ -1,0 +1,23 @@
+topics:
+  - Academic Careers
+  - American Culture
+  - Graduate School
+  - Career Exploration
+  - Ethics, Responsible Conduct of Research
+  - Grants and Grant Writing
+  - Industry Careers
+  - Informational Session
+  - Job Search Skills
+  - Language Skills
+  - Leadership - Personal/Group Interactions
+  - Management
+  - Networking Opportunities
+  - Orientation
+  - Personal Development
+  - Professional (Medical/Dental) School
+  - Science
+  - Science Skills
+  - Speaking
+  - Teaching/Mentoring
+  - Wellness
+  - Writing

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -34,6 +34,12 @@ class EventsController < ApplicationController
     rescue Page::NotFound
       nil
     end
+
+    @not_found = begin
+      ContentBlock.find_by_path "no-events-found/block"
+    rescue ContentBlock::NotFound
+      nil
+    end
   end
 
   def show

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,14 +9,22 @@ class EventsController < ApplicationController
 
     if params[:audience] && params[:audience].size > 0
       @selected_audiences = params[:audience]
-      @events = @events.select { |event| @selected_audiences.any? { |el| event.audience.include? el } }
+      @events = @events.select { |event|
+        event.audience.size > 0 && @selected_audiences.any? { |audience|
+          event.audience.include? audience
+        }
+      }
     else
       @selected_audiences = []
     end
 
     if params[:topic] && params[:topic].size > 0
       @selected_topics = params[:topic]
-      @events = @events.select { |event| @selected_topics.any? { |el| event.topic.include? el } }
+      @events = @events.select { |event|
+        event.topic.size > 0 && @selected_topics.any? { |topic|
+          event.topic.include? topic
+        }
+      }
     else
       @selected_topics = []
     end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,18 +3,23 @@ class EventsController < ApplicationController
 
   def index
     @audiences = Event.audiences
+    @topics = Event.topics
 
-    @selected_audiences = if params[:audience].nil? || params[:audience].size == 0
-      @audiences
+    @events = Event.all
+
+    if params[:audience] && params[:audience].size > 0
+      @selected_audiences = params[:audience]
+      @events = @events.select { |event| @selected_audiences.any? { |el| event.audience.include? el } }
     else
-      params[:audience]
+      @selected_audiences = []
     end
 
-    @events = Event.all.select { |event|
-      event.audience.empty? || @selected_audiences.any? { |el|
-        event.audience.include? el
-      }
-    }
+    if params[:topic] && params[:topic].size > 0
+      @selected_topics = params[:topic]
+      @events = @events.select { |event| @selected_topics.any? { |el| event.topic.include? el } }
+    else
+      @selected_topics = []
+    end
 
     @page = begin
       Page.find_by_path "events"

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,6 +14,11 @@ class Event
     data["audiences"] || []
   end
 
+  def self.topics(file = Rails.root.join("_settings/topics.yml"))
+    data = YAML.safe_load File.read(file), fallback: {}
+    data["topics"] || []
+  end
+
   def self.find_by_path(path, base: Rails.root.join("_events"), try_index: false)
     super path, base: base, try_index: try_index
   end
@@ -22,6 +27,7 @@ class Event
   has_field :title
   has_field :speakers, :audience, default: []
   has_field :accommodations, default: {}
+  has_field :topic
 
   def initialize(path, base: nil)
     @filename = path.basename(".md")

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -27,7 +27,7 @@ class Event
   has_field :title
   has_field :speakers, :audience, default: []
   has_field :accommodations, default: {}
-  has_field :topic
+  has_field :topic, default: []
 
   def initialize(path, base: nil)
     @filename = path.basename(".md")

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -52,54 +52,60 @@
   </aside>
   <div class="grid-col-12 desktop:grid-col-8">
 
-    <ul class="usa-collection oite-events">
-      <% @events.each do |event| %>
-        <li class="usa-collection__item oite-event">
-          <div class="usa-collection__calendar-date">
-            <time datetime="<%= event.date %>">
-              <span class="usa-collection__calendar-date-month"><%= event.date.strftime("%b").upcase %></span>
-              <span class="usa-collection__calendar-date-day"><%= event.date.strftime("%d") %></span>
-            </time>
-          </div>
-          <div class="usa-collection__body">
-            <div class="usa-collection__heading">
-              <h3 class="margin-0">
-                <%= link_to event.title, event_path(event), class: "usa-link" %>
-              </h3>
-              <div class="oite-event__time text-italic">
-                <time datetime="<%= event.start.strftime("%F") %>"><%= event.start.strftime("%A, %B %-d, %Y %l:%M %p") %></time>
-                –
-                <time datetime="<%= event.end.strftime("%F") %>"><%= event.end.strftime("%l:%M %p") %></time>
-              </div>
+    <% if !@events.empty? %>
+      <ul class="usa-collection oite-events">
+        <% @events.each do |event| %>
+          <li class="usa-collection__item oite-event">
+            <div class="usa-collection__calendar-date">
+              <time datetime="<%= event.date %>">
+                <span class="usa-collection__calendar-date-month"><%= event.date.strftime("%b").upcase %></span>
+                <span class="usa-collection__calendar-date-day"><%= event.date.strftime("%d") %></span>
+              </time>
             </div>
-            <div class="usa-collection__description">
-              <% unless event.speaker_names.empty? %>
-                <div class="oite-event__speakers margin-y-1">
-                  <h4 class="margin-0">Speakers</h4>
-                  <ul class="usa-list">
-                    <% event.speaker_names.each do |speaker| %>
-                    <li>
-                      <%= speaker%>
-                    </li>
-                    <% end %>
-                  </ul>
+            <div class="usa-collection__body">
+              <div class="usa-collection__heading">
+                <h3 class="margin-0">
+                  <%= link_to event.title, event_path(event), class: "usa-link" %>
+                </h3>
+                <div class="oite-event__time text-italic">
+                  <time datetime="<%= event.start.strftime("%F") %>"><%= event.start.strftime("%A, %B %-d, %Y %l:%M %p") %></time>
+                  –
+                  <time datetime="<%= event.end.strftime("%F") %>"><%= event.end.strftime("%l:%M %p") %></time>
                 </div>
-              <% end %>
-              <div class="usa-prose p-summary">
-                <%= event.rendered_content%>
               </div>
-              <div class="oite-event__tags margin-y-1">
-                <% event.audience.each do |audience| %>
-                  <%= link_to audience, events_path(audience: [audience]), class: "usa-button usa-button--accent-cool text-bold text-uppercase font-ui-3xs margin-1" %>
+              <div class="usa-collection__description">
+                <% unless event.speaker_names.empty? %>
+                  <div class="oite-event__speakers margin-y-1">
+                    <h4 class="margin-0">Speakers</h4>
+                    <ul class="usa-list">
+                      <% event.speaker_names.each do |speaker| %>
+                      <li>
+                        <%= speaker%>
+                      </li>
+                      <% end %>
+                    </ul>
+                  </div>
                 <% end %>
-                <% event.topic.each do |topic| %>
-                  <%= link_to topic, events_path(topic: [topic]), class: "usa-button usa-button--accent-cool text-bold text-uppercase font-ui-3xs margin-1" %>
-                <% end %>
+                <div class="usa-prose p-summary">
+                  <%= event.rendered_content%>
+                </div>
+                <div class="oite-event__tags margin-y-1">
+                  <% event.audience.each do |audience| %>
+                    <%= link_to audience, events_path(audience: [audience]), class: "usa-button usa-button--accent-cool text-bold text-uppercase font-ui-3xs margin-1" %>
+                  <% end %>
+                  <% event.topic.each do |topic| %>
+                    <%= link_to topic, events_path(topic: [topic]), class: "usa-button usa-button--accent-cool text-bold text-uppercase font-ui-3xs margin-1" %>
+                  <% end %>
+                </div>
               </div>
             </div>
-          </div>
-        </li>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <% if @not_found %>
+        <%= @not_found.rendered_content %>
       <% end %>
-    </ul>
+    <% end %>
   </div>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -90,9 +90,10 @@
               </div>
               <div class="oite-event__tags margin-y-1">
                 <% event.audience.each do |audience| %>
-                  <%= link_to audience, events_path(audience: [audience]), class: "usa-button usa-button--accent-cool text-bold text-uppercase font-ui-2xs" %>
+                  <%= link_to audience, events_path(audience: [audience]), class: "usa-button usa-button--accent-cool text-bold text-uppercase font-ui-3xs margin-1" %>
                 <% end %>
                 <% event.topic.each do |topic| %>
+                  <%= link_to topic, events_path(topic: [topic]), class: "usa-button usa-button--accent-cool text-bold text-uppercase font-ui-3xs margin-1" %>
                 <% end %>
               </div>
             </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -13,27 +13,37 @@
   <fieldset class="usa-fieldset">
     <legend class="usa-legend"><h3>Filter by audience</h3></legend>
     <% @audiences.each do |audience| %>
-      <%
-        is_selected = @selected_audiences.include?(audience)
-        is_only_one_selected = is_selected && @selected_audiences.size == 1
-      %>
-      <% if is_only_one_selected then %>
-        <% # We're disabling the checkbox, but we need to persist the value on form submit %>
-        <input type="hidden" name="audience[]" value="<%= audience %>">
-      <% end %>
       <div class="usa-checkbox">
         <input
-          class="usa-checkbox__input usa-checkbox__input--tile"
+          class="usa-checkbox__input"
           id="filter-<%= audience.parameterize %>"
           type="checkbox"
           name="audience[]"
           value="<%= audience %>"
-          <%= if is_selected then "checked" end %>
-          <%= if is_only_one_selected then "disabled" end %>
+          <%= if is_selected = @selected_audiences.include?(audience) then "checked" end %>
           data-submit-form-on-click
         />
         <label class="usa-checkbox__label" for="filter-<%= audience.parameterize %>">
           <%= audience %>
+        </label>
+      </div>
+    <% end %>
+  </fieldset>
+  <fieldset class="usa-fieldset">
+    <legend class="usa-legend"><h3>Filter by topic</h3></legend>
+    <% @topics.each do |topic| %>
+      <div class="usa-checkbox">
+        <input
+          class="usa-checkbox__input"
+          id="filter-topic-<%= topic.parameterize %>"
+          type="checkbox"
+          name="topic[]"
+          value="<%= topic %>"
+          <%= if @selected_topics.include?(topic) then "checked" end %>
+          data-submit-form-on-click
+        />
+        <label class="usa-checkbox__label" for="filter-topic-<%= topic.parameterize %>">
+          <%= topic %>
         </label>
       </div>
     <% end %>
@@ -78,9 +88,11 @@
               <div class="usa-prose p-summary">
                 <%= event.rendered_content%>
               </div>
-              <div class="oite-event__audiences margin-y-1">
+              <div class="oite-event__tags margin-y-1">
                 <% event.audience.each do |audience| %>
                   <%= link_to audience, events_path(audience: [audience]), class: "usa-button usa-button--accent-cool text-bold text-uppercase font-ui-2xs" %>
+                <% end %>
+                <% event.topic.each do |topic| %>
                 <% end %>
               </div>
             </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -20,7 +20,7 @@
           type="checkbox"
           name="audience[]"
           value="<%= audience %>"
-          <%= if is_selected = @selected_audiences.include?(audience) then "checked" end %>
+          <%= if @selected_audiences.include?(audience) then "checked" end %>
           data-submit-form-on-click
         />
         <label class="usa-checkbox__label" for="filter-<%= audience.parameterize %>">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -22,6 +22,16 @@
           </ul>
         </div>
       <% end %>
+      <% unless @event.topic.empty? %>
+        <div class="oite-event__topics margin-y-1">
+          <h4>Topics</h4>
+          <ul class="usa-list--unstyled">
+            <% @event.topic.each do |topic| %>
+              <li><span class="usa-tag"><%= topic %></span></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
       <% unless @event.audience.empty? %>
         <div class="oite-event__audiences margin-y-1">
           <h4>This event is recommended for</h4>

--- a/app/views/pages/netlify_config.yaml.erb
+++ b/app/views/pages/netlify_config.yaml.erb
@@ -47,6 +47,12 @@ collections:
         fields:
           - label: "Full Name"
             name: name
+      - label: Topic
+        name: "topic"
+        widget: "select"
+        required: false
+        multiple: true
+        options: <%= raw JSON.generate Event.topics %>
       - label: "Intended Audience"
         name: "audience"
         widget: "select"

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -2,13 +2,14 @@ require "rails_helper"
 
 RSpec.describe EventsController do
   before {
-    allow(Rails).to receive(:root).and_return(file_fixture("_pages").join("..").cleanpath)
+    allow(Rails).to receive(:root).and_return(file_fixture("_events").join("..").cleanpath)
     allow(Date).to receive(:today).and_return(Date.new(2022, 4, 4))
   }
 
-  it "shows events for all audiences by default" do
+  it "shows events for all audiences + topics by default" do
     get :index
-    expect(assigns(:selected_audiences)).to eq(["Summer Interns", "Postbacs", "Graduate Students", "Postdocs/Fellows", "NIH Staff Scientist/Staff Clinician"])
+    expect(assigns(:selected_audiences)).to eq([])
+    expect(assigns(:selected_topics)).to eq([])
   end
 
   it "does not show events in the past" do
@@ -21,13 +22,20 @@ RSpec.describe EventsController do
   end
 
   it "can be filtered by audience" do
-    request.params[:selected_audiences] = ["Summer Interns"]
-    get :index
+    get :index, params: {audience: ["Summer Interns"]}
     expect(assigns(:events)).not_to be_nil
     expect(assigns(:events)).not_to be_empty
-
     expect(assigns(:events)).to all satisfy { |ev|
-      ev.audience.empty? || ev.audience.include?("Summer Interns")
+      ev.audience.include? "Summer Interns"
+    }
+  end
+
+  it "can be filtered by topic" do
+    get :index, params: {topic: ["Graduate School"]}
+    expect(assigns(:events)).not_to be_nil
+    expect(assigns(:events)).not_to be_empty
+    expect(assigns(:events)).to all satisfy { |ev|
+      ev.topic.include? "Graduate School"
     }
   end
 

--- a/spec/fixtures/files/_events/202257-training-event.md
+++ b/spec/fixtures/files/_events/202257-training-event.md
@@ -14,5 +14,7 @@ audience:
 accommodations:
   name: Ryan Ahearn
   email: ryan.ahearn@gsa.gov
+topic:
+  - Graduate School
 ---
 This is the **formatted** description of the training event.

--- a/spec/fixtures/files/_settings/topics.yml
+++ b/spec/fixtures/files/_settings/topics.yml
@@ -1,0 +1,23 @@
+topics:
+  - Academic Careers
+  - American Culture
+  - Graduate School
+  - Career Exploration
+  - Ethics, Responsible Conduct of Research
+  - Grants and Grant Writing
+  - Industry Careers
+  - Informational Session
+  - Job Search Skills
+  - Language Skills
+  - Leadership - Personal/Group Interactions
+  - Management
+  - Networking Opportunities
+  - Orientation
+  - Personal Development
+  - Professional (Medical/Dental) School
+  - Science
+  - Science Skills
+  - Speaking
+  - Teaching/Mentoring
+  - Wellness
+  - Writing


### PR DESCRIPTION
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/364697/162502055-048583db-5eeb-414d-9a3d-d572abe9857d.png">

This PR: 
- Adds a new `topic` field similar to `audience` to the Event model
- Allows filtering event listing by topics
- Switches up filter controls on the event listing page so that nothing selected = show all topics / audiences (this made more sense to me with _lots_ of checkboxes)
- Adds a "no events found" message when filtering (sourced from a CMS-editable content block)

(Still completely not committed to the UX on the event list.)

Closes https://trello.com/c/bQQkkPKG/113-current-nih-postbac-search-upcoming-events-for-specific-need