### PR TITLE
Draft: Save the updated_by and updated_at data for netlify edits

### DIFF
--- a/_blocks/hours-location/block.md
+++ b/_blocks/hours-location/block.md
@@ -1,4 +1,14 @@
 ---
 name: Hours
+updated_by: ryan.ahearn+local@gsa.gov
+updated_at: 2022-04-18T16:11:05.387Z
 ---
-**Hours and Location:** OITE is housed on the second floor of Building 2. It is open from 8:00 am to 5:00 pm. The office maintains an open-door policy and welcomes trainees to drop by anytime.  However, individual staff members keep different schedules.  Sending an email before heading over will ensure that the person you want to see is available.
+### Location
+
+OITE is housed on the second floor of Building 2.
+
+### Hours
+
+It is open from 8:00 am to 5:00 pm.
+
+The office maintains an open-door policy and welcomes trainees to drop by anytime.  However, individual staff members keep different schedules.  Sending an email before heading over will ensure that the person you want to see is available.

--- a/app/javascript/ReadOnlyControl.jsx
+++ b/app/javascript/ReadOnlyControl.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+// eslint-disable-next-line react/prefer-stateless-function
+export default class ReadOnlyControl extends React.Component {
+  render() {
+    const { value } = this.props;
+    return <p>{value.toString()}</p>;
+  }
+}
+
+ReadOnlyControl.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
+};
+
+ReadOnlyControl.defaultProps = {
+  value: "",
+};

--- a/app/javascript/ReadOnlyPreview.jsx
+++ b/app/javascript/ReadOnlyPreview.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+// eslint-disable-next-line react/prefer-stateless-function
+export default class ReadOnlyPreview extends React.Component {
+  render() {
+    const { field, value } = this.props;
+    if (field.get("hide_preview")) return null;
+    return (
+      <p>
+        <strong>{field.get("label")}:</strong> {value.toString()}
+      </p>
+    );
+  }
+}
+
+ReadOnlyPreview.propTypes = {
+  field: PropTypes.shape({ get: PropTypes.func.isRequired }).isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)])
+    .isRequired,
+};

--- a/app/javascript/netlify-app.js
+++ b/app/javascript/netlify-app.js
@@ -3,6 +3,8 @@ import { GitGatewayBackend } from "netlify-cms-backend-git-gateway";
 import AuthenticationPage from "./AuthenticationPage";
 import ContentBlockEditorComponent from "./ContentBlockEditorComponent";
 import VideoEditorComponent from "./VideoEditorComponent";
+import ReadOnlyControl from "./ReadOnlyControl";
+import ReadOnlyPreview from "./ReadOnlyPreview";
 
 class NihGateway extends GitGatewayBackend {
   // eslint-disable-next-line class-methods-use-this
@@ -22,6 +24,7 @@ class NihGateway extends GitGatewayBackend {
 CMS.registerBackend("nih-gateway", NihGateway);
 CMS.registerEditorComponent(ContentBlockEditorComponent);
 CMS.registerEditorComponent(VideoEditorComponent);
+CMS.registerWidget("readonly", ReadOnlyControl, ReadOnlyPreview);
 
 CMS.registerEventListener({
   name: "preSave",

--- a/app/javascript/netlify-app.js
+++ b/app/javascript/netlify-app.js
@@ -34,7 +34,7 @@ CMS.registerEventListener({
 CMS.registerEventListener({
   name: "preSave",
   handler: ({ entry, author: { login } }) =>
-    entry.get("data").set("updated_by", `${login}`),
+    entry.get("data").set("updated_by", login),
 });
 
 CMS.init();

--- a/app/javascript/netlify-app.js
+++ b/app/javascript/netlify-app.js
@@ -22,4 +22,18 @@ class NihGateway extends GitGatewayBackend {
 CMS.registerBackend("nih-gateway", NihGateway);
 CMS.registerEditorComponent(ContentBlockEditorComponent);
 CMS.registerEditorComponent(VideoEditorComponent);
+
+CMS.registerEventListener({
+  name: "preSave",
+  handler: ({ entry }) => {
+    return entry.get("data").set("updated_at", new Date().toISOString());
+  },
+});
+CMS.registerEventListener({
+  name: "preSave",
+  handler: ({ entry, author: { login } }) => {
+    return entry.get("data").set("updated_by", `${login}`);
+  },
+});
+
 CMS.init();

--- a/app/javascript/netlify-app.js
+++ b/app/javascript/netlify-app.js
@@ -25,15 +25,13 @@ CMS.registerEditorComponent(VideoEditorComponent);
 
 CMS.registerEventListener({
   name: "preSave",
-  handler: ({ entry }) => {
-    return entry.get("data").set("updated_at", new Date().toISOString());
-  },
+  handler: ({ entry }) =>
+    entry.get("data").set("updated_at", new Date().toISOString()),
 });
 CMS.registerEventListener({
   name: "preSave",
-  handler: ({ entry, author: { login } }) => {
-    return entry.get("data").set("updated_by", `${login}`);
-  },
+  handler: ({ entry, author: { login } }) =>
+    entry.get("data").set("updated_by", `${login}`),
 });
 
 CMS.init();

--- a/app/models/concerns/netlify_content.rb
+++ b/app/models/concerns/netlify_content.rb
@@ -36,6 +36,10 @@ module NetlifyContent
     attr_reader :parsed_file
   end
 
+  def yaml_loader
+    FrontMatterParser::Loader::Yaml.new(allowlist_classes: [Time])
+  end
+
   def content_document
     Kramdown::Document.new(parsed_file.content, input: "CustomParser")
   end

--- a/app/models/content_block.rb
+++ b/app/models/content_block.rb
@@ -8,6 +8,6 @@ class ContentBlock
   has_field :name
 
   def initialize(path, base: nil)
-    @parsed_file = FrontMatterParser::Parser.parse_file(path)
+    @parsed_file = FrontMatterParser::Parser.parse_file(path, loader: yaml_loader)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -31,8 +31,7 @@ class Event
 
   def initialize(path, base: nil)
     @filename = path.basename(".md")
-    loader = FrontMatterParser::Loader::Yaml.new(allowlist_classes: [Time])
-    @parsed_file = FrontMatterParser::Parser.parse_file(path, loader: loader)
+    @parsed_file = FrontMatterParser::Parser.parse_file(path, loader: yaml_loader)
   end
 
   def to_param

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -69,8 +69,7 @@ class Page
       full_path
     end.relative_path_from(base)
     @base = base
-    loader = FrontMatterParser::Loader::Yaml.new(allowlist_classes: [Time])
-    @parsed_file = FrontMatterParser::Parser.parse_file(full_path, loader: loader)
+    @parsed_file = FrontMatterParser::Parser.parse_file(full_path, loader: yaml_loader)
   end
 
   def children

--- a/app/views/pages/netlify_config.yaml.erb
+++ b/app/views/pages/netlify_config.yaml.erb
@@ -15,8 +15,6 @@ collections:
     slug: "{{date.year}}{{date.month}}{{date.day}}-{{slug}}"
     fields:
       - {label: "Name", name: "title"}
-      - {name: "updated_by", widget: hidden}
-      - {name: "updated_at", widget: hidden}
       - label: "Event Date"
         name: "date"
         widget: "object"
@@ -70,6 +68,8 @@ collections:
           - {label: "Email", name: email, required: false}
           - {label: "Phone Number", name: phone, required: false}
       - {label: "Description", name: "body", widget: "markdown"}
+      - {name: "updated_by", label: "Last Updated By", hide_preview: true, required: false, widget: "readonly"}
+      - {name: "updated_at", label: "Last Updated At", hide_preview: false, required: false, widget: "readonly"}
 <% end %>
 <% if policy(:netlify).cms? %>
   - name: block
@@ -79,9 +79,9 @@ collections:
     nested: {depth: 2}
     meta: {path: {widget: string, label: "Folder", index_file: "block"}}
     fields:
+      - {name: "updated_by", label: "Last Updated By", hide_preview: true, required: false, widget: "readonly"}
+      - {name: "updated_at", label: "Last Updated At", hide_preview: true, required: false, widget: "readonly"}
       - {label: "Content Name", name: "name"}
-      - {name: "updated_by", widget: hidden}
-      - {name: "updated_at", widget: hidden}
       - {label: "Body", name: "body", widget: "markdown"}
   - name: page
     label: "Page"
@@ -91,8 +91,6 @@ collections:
     meta: {path: {widget: string, label: "Path", index_file: "index"}}
     fields:
       - {label: "Title", name: "title"}
-      - {name: "updated_by", widget: hidden}
-      - {name: "updated_at", widget: hidden}
       - {label: "Public", name: "public", widget: "boolean", default: true}
       - {label: "Expires At", name: "expires_at", widget: "datetime", default: "", required: false}
       - label: "Replaced By Page"
@@ -115,6 +113,8 @@ collections:
             value_field: "{{slug}}"
             display_fields: ["name"]
       - {label: "Body", name: "body", widget: "markdown"}
+      - {name: "updated_by", label: "Last Updated By", hide_preview: true, required: false, widget: "readonly"}
+      - {name: "updated_at", label: "Last Updated At", hide_preview: false, required: false, widget: "readonly"}
   - name: settings
     label: Site settings
     editor:
@@ -125,8 +125,8 @@ collections:
         description: "Configure primary navigation at the top of every page."
         file: "_settings/navigation.yml"
         fields:
-          - {name: "updated_by", widget: hidden}
-          - {name: "updated_at", widget: hidden}
+          - {name: "updated_by", label: "Last Updated By", hide_preview: true, required: false, widget: "readonly"}
+          - {name: "updated_at", label: "Last Updated At", hide_preview: true, required: false, widget: "readonly"}
           - name: items
             label: Primary navigation items
             label_singular: Primary navigation item
@@ -150,8 +150,8 @@ collections:
         description: "Configure the footer at the bottom of every page."
         file: "_settings/footer.yml"
         fields:
-          - {name: "updated_by", widget: hidden}
-          - {name: "updated_at", widget: hidden}
+          - {name: "updated_by", label: "Last Updated By", hide_preview: true, required: false, widget: "readonly"}
+          - {name: "updated_at", label: "Last Updated At", hide_preview: true, required: false, widget: "readonly"}
           - name: agency_name
             label: Agency name
             widget: string

--- a/app/views/pages/netlify_config.yaml.erb
+++ b/app/views/pages/netlify_config.yaml.erb
@@ -15,6 +15,8 @@ collections:
     slug: "{{date.year}}{{date.month}}{{date.day}}-{{slug}}"
     fields:
       - {label: "Name", name: "title"}
+      - {name: "updated_by", widget: hidden}
+      - {name: "updated_at", widget: hidden}
       - label: "Event Date"
         name: "date"
         widget: "object"
@@ -78,6 +80,8 @@ collections:
     meta: {path: {widget: string, label: "Folder", index_file: "block"}}
     fields:
       - {label: "Content Name", name: "name"}
+      - {name: "updated_by", widget: hidden}
+      - {name: "updated_at", widget: hidden}
       - {label: "Body", name: "body", widget: "markdown"}
   - name: page
     label: "Page"
@@ -87,6 +91,8 @@ collections:
     meta: {path: {widget: string, label: "Path", index_file: "index"}}
     fields:
       - {label: "Title", name: "title"}
+      - {name: "updated_by", widget: hidden}
+      - {name: "updated_at", widget: hidden}
       - {label: "Public", name: "public", widget: "boolean", default: true}
       - {label: "Expires At", name: "expires_at", widget: "datetime", default: "", required: false}
       - label: "Replaced By Page"
@@ -119,6 +125,8 @@ collections:
         description: "Configure primary navigation at the top of every page."
         file: "_settings/navigation.yml"
         fields:
+          - {name: "updated_by", widget: hidden}
+          - {name: "updated_at", widget: hidden}
           - name: items
             label: Primary navigation items
             label_singular: Primary navigation item
@@ -142,6 +150,8 @@ collections:
         description: "Configure the footer at the bottom of every page."
         file: "_settings/footer.yml"
         fields:
+          - {name: "updated_by", widget: hidden}
+          - {name: "updated_at", widget: hidden}
           - name: agency_name
             label: Agency name
             widget: string

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "postcss": "^8.4.7",
     "postcss-cli": "^9.1.0",
     "postcss-scss": "^4.0.3",
+    "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "uswds": "^2.13.1",


### PR DESCRIPTION
Automatically saves the user who created or updated a record and a timestamp of when the update was submitted.

<img width="1438" alt="Screen Shot 2022-04-18 at 4 18 32 PM" src="https://user-images.githubusercontent.com/285842/163871430-0e904b0e-f2ea-41fd-8a60-8d8dc329cdbc.png">

Known issue: You _have_ to set `required: false` and have `(OPTIONAL)` in the label name or the first save won't work. Doesn't effect the use but it looks weird.

TODO:

- [x] use a custom widget that displays that info in a disabled control so approvers can see it in Netlify.
- [x] verify that updating labels doesn't replace the author's email with the approver's email

closes https://trello.com/c/1aXqkJkF/186-as-a-content-approver-i-want-to-know-who-edited-this-page-event-content-block

