### PR TITLE
Allow Time in menu and footer files

### DIFF
--- a/app/models/footer.rb
+++ b/app/models/footer.rb
@@ -11,7 +11,7 @@ class Footer
   attr_reader :data
 
   def self.load(file = Rails.root.join("_settings", "footer.yml"))
-    data = YAML.safe_load File.read(file), fallback: {}
+    data = YAML.safe_load File.read(file), [Time], fallback: {}
     new data
   end
 

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -32,7 +32,7 @@ class Menu
   end
 
   def self.load(file, pages)
-    data = YAML.safe_load File.read(file), fallback: {}
+    data = YAML.safe_load File.read(file), [Time], fallback: {}
     items = (data["items"] || []).map { |i|
       page = Page.find_by_slug(i["page"], pages)
       if page

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="<%= I18n.locale %>">
   <head>
-    <title>NihOiteExperiments</title>
+    <title>NIH OITE Experiments</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,5 +16,5 @@ en:
       demo_banner: TEST SITE - Do not use real personal information (demo purposes only) - TEST SITE
       menu: Menu
       primary: Primary navigation
-      title: Nih Oite Experiments
+      title: NIH OITE Experiments
     skip_link: Skip to main content


### PR DESCRIPTION
`updated_at` wasn't properly deserialized since those classes don't include `NetlifyContent`

also updates the site header to proper capitalization.

closes: https://trello.com/c/UnY7AcXl/203-fix-yaml-class-loading-issue-on-site-settings-that-was-triggered-during-demo-day