### PR TITLE
Use owasp stable for the full daily scan

### DIFF
--- a/.github/workflows/owasp-daily-scan.yml
+++ b/.github/workflows/owasp-daily-scan.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run OWASP Full Scan
         uses: zaproxy/action-full-scan@v0.3.0
         with:
-          docker_name: 'owasp/zap2docker-weekly'
+          docker_name: 'owasp/zap2docker-stable'
           target: 'http://localhost:3000/'
           fail_action: true
           rules_file_name: 'zap.conf'


### PR DESCRIPTION
The new weekly build seems to have an error in it when parsing the results from the full scan.

To use the stable build locally for a full scan, run `./bin/owasp-scan -fs`

Link to last failing daily scan: https://github.com/18F/nih-oite-experiments/actions/runs/2195543889