### PR TITLE
Fix issue with video embeds

### DIFF
--- a/app/javascript/VideoEditorComponent.test.jsx
+++ b/app/javascript/VideoEditorComponent.test.jsx
@@ -2,6 +2,27 @@ import React from "react";
 import VideoEditorComponent from "./VideoEditorComponent";
 
 describe("VideoEditorComponent", () => {
+  test("#fromBlock", () => {
+    const input = `
+
+    This is the home page!
+
+    {::video url="https://www.youtube.com/watch?v=SAK117AmzSE" alt="" /}
+
+    {::content_block slug="hours-location/block" /}
+
+  `;
+
+    const match = input.match(VideoEditorComponent.pattern);
+
+    const data = VideoEditorComponent.fromBlock(match);
+
+    expect(data).toEqual({
+      url: "https://www.youtube.com/watch?v=SAK117AmzSE",
+      alt: "",
+    });
+  });
+
   describe("#toPreview", () => {
     const tests = [
       {

--- a/app/javascript/kramdown.jsx
+++ b/app/javascript/kramdown.jsx
@@ -34,7 +34,7 @@ function unescapeExtensionAttribute(value) {
  * @returns {RegExp} A regular expression that will match a kramdown extension tag.
  */
 function makeExtensionRegex(name) {
-  return new RegExp(`{::${name}\\s+((${attrRegex}\\s*)*)\\s*/}`, "gi");
+  return new RegExp(`{::${name}\\s+((${attrRegex}\\s*)*)\\s*/}`, "i");
 }
 
 /**
@@ -65,12 +65,11 @@ export default function createKramdownExtensionEditorComponent(options) {
 
   // Convert a regex match back to an object whose keys are the field names and values are the field values
   const fromBlock = (match) => {
-    const attrs = match[1];
     const rx = new RegExp(attrRegex, "gi");
 
     const parsed = {};
 
-    for (let m = rx.exec(attrs); m; m = rx.exec(attrs)) {
+    for (let m = rx.exec(match[0]); m; m = rx.exec(match[0])) {
       const attrName = m[1];
       const attrValue = m[2];
       parsed[attrName] = unescapeExtensionAttribute(attrValue);


### PR DESCRIPTION
Video embeds were broken due to a regular expression issue. This PR resolves the issue and adds an additional test to cover.

Before:

<img width="514" alt="image" src="https://user-images.githubusercontent.com/364697/164511734-2f0b26da-df36-4c03-a51b-7c5ebf3d1de5.png">

After:

<img width="537" alt="image" src="https://user-images.githubusercontent.com/364697/164511790-21e14437-5312-44e4-9983-c6e02f07617e.png">


Trello: https://trello.com/c/tttCdequ/208-regression-in-video-embedding